### PR TITLE
ApiGatewayHandler accepts null input

### DIFF
--- a/apigateway/src/main/java/com/github/awsjavakit/apigateway/bodyparsing/DefaultJsonParser.java
+++ b/apigateway/src/main/java/com/github/awsjavakit/apigateway/bodyparsing/DefaultJsonParser.java
@@ -1,6 +1,7 @@
 package com.github.awsjavakit.apigateway.bodyparsing;
 
 import static com.gtihub.awsjavakit.attempt.Try.attempt;
+import static java.util.Objects.nonNull;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -17,6 +18,10 @@ public class DefaultJsonParser<I> implements BodyParser<I> {
 
   @Override
   public I parseBody(String body) {
+    return nonNull(body) ? parseNonNullBody(body) : null;
+  }
+
+  private I parseNonNullBody(String body) {
     var json = attempt(() -> objectMapper.readTree(body)).orElseThrow();
     if (inputIsStringAndExpectedInputIsString(json)) {
       return inputAsString(json);

--- a/apigateway/src/test/java/com/github/awsjavakit/apigateway/ApiGatewayHandlerTest.java
+++ b/apigateway/src/test/java/com/github/awsjavakit/apigateway/ApiGatewayHandlerTest.java
@@ -86,7 +86,7 @@ public class ApiGatewayHandlerTest {
   void shouldParseNonDefinedInputAsNullInstanceOfSuppliedType() throws IOException {
     var request = ApiGatewayRequestBuilder.create(objectMapper).build();
     var observer = new BodyObserver<SampleInput>();
-    this.handler = new EchoHandler<>(SampleInput.class, objectMapper, observer);
+    this.handler = new EchoHandler<>(Void.class, objectMapper, observer);
     handler.handleRequest(request, outputStream, EMPTY_CONTEXT);
     var bodyInsideHandler = observer.getBody();
     assertThat(bodyInsideHandler).isEqualTo(NULL_SAMPLE_INPUT);

--- a/apigateway/src/test/java/com/github/awsjavakit/apigateway/ApiGatewayHandlerTest.java
+++ b/apigateway/src/test/java/com/github/awsjavakit/apigateway/ApiGatewayHandlerTest.java
@@ -5,6 +5,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.amazonaws.services.lambda.runtime.Context;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.awsjavakit.apigateway.observers.BodyObserver;
+import com.github.awsjavakit.apigateway.observers.InputObserver;
 import com.github.awsjavakit.testingutils.ApiGatewayRequestBuilder;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -20,6 +22,7 @@ public class ApiGatewayHandlerTest {
 
   public static final Context EMPTY_CONTEXT = null;
   public static final int ARBITRARY_CEILING = 120;
+  public static final SampleInput NULL_SAMPLE_INPUT = null;
   private static final int MIN_RANDOM_STRING_LENGTH = 10;
   private static final int MAX_RANDOM_STRING_LENGTH = 20;
   private static final Map<String, String> CONTENT_TYPE_APPLICATION_JSON = Map.of("Content-Type",
@@ -61,7 +64,7 @@ public class ApiGatewayHandlerTest {
   @Test
   void shouldReturnBodyAsIsWhenInputTypeIsString() throws IOException {
     var sampleInput = randomString();
-    this.handler = new EchoHandler(objectMapper, InputObserver.noOp());
+    this.handler = new EchoHandler<>(String.class, objectMapper, InputObserver.noOp());
     handler.handleRequest(createRequest(sampleInput), outputStream, EMPTY_CONTEXT);
     var response = GatewayResponse.fromOutputStream(outputStream, objectMapper);
     var responseBody = response.getBody(objectMapper, String.class);
@@ -73,10 +76,21 @@ public class ApiGatewayHandlerTest {
     var sampleInput = randomString();
     var expectedException = new NotFoundException();
     this.handler =
-      new EchoHandler(objectMapper, InputObserver.throwException(expectedException));
+      new EchoHandler<>(String.class, objectMapper, InputObserver.throwException(expectedException));
     handler.handleRequest(createRequest(sampleInput), outputStream, EMPTY_CONTEXT);
     var response = GatewayResponse.fromOutputStream(outputStream, objectMapper);
     assertThat(response.getStatusCode()).isEqualTo(expectedException.statusCode());
+  }
+
+  @Test
+  void shouldParseNonDefinedInputAsNullInstanceOfSuppliedType() throws IOException {
+    var request = ApiGatewayRequestBuilder.create(objectMapper).build();
+    var observer = new BodyObserver<SampleInput>();
+    this.handler = new EchoHandler<>(SampleInput.class, objectMapper, observer);
+    handler.handleRequest(request, outputStream, EMPTY_CONTEXT);
+    var bodyInsideHandler = observer.getBody();
+    assertThat(bodyInsideHandler).isEqualTo(NULL_SAMPLE_INPUT);
+
   }
 
   private SampleInput createSampleInput() {

--- a/apigateway/src/test/java/com/github/awsjavakit/apigateway/ApiGatewayHandlerTest.java
+++ b/apigateway/src/test/java/com/github/awsjavakit/apigateway/ApiGatewayHandlerTest.java
@@ -84,13 +84,17 @@ public class ApiGatewayHandlerTest {
 
   @Test
   void shouldParseNonDefinedInputAsNullInstanceOfSuppliedType() throws IOException {
-    var request = ApiGatewayRequestBuilder.create(objectMapper).build();
+    var request = requestWithoutBody();
     var observer = new BodyObserver<SampleInput>();
     this.handler = new EchoHandler<>(Void.class, objectMapper, observer);
     handler.handleRequest(request, outputStream, EMPTY_CONTEXT);
     var bodyInsideHandler = observer.getBody();
     assertThat(bodyInsideHandler).isEqualTo(NULL_SAMPLE_INPUT);
 
+  }
+
+  private InputStream requestWithoutBody() {
+    return ApiGatewayRequestBuilder.create(objectMapper).build();
   }
 
   private SampleInput createSampleInput() {

--- a/apigateway/src/test/java/com/github/awsjavakit/apigateway/EchoHandler.java
+++ b/apigateway/src/test/java/com/github/awsjavakit/apigateway/EchoHandler.java
@@ -3,20 +3,23 @@ package com.github.awsjavakit.apigateway;
 import com.amazonaws.services.lambda.runtime.Context;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.awsjavakit.apigateway.exception.ApiGatewayException;
+import com.github.awsjavakit.apigateway.observers.InputObserver;
 import java.util.Arrays;
 import java.util.List;
 
-public class EchoHandler extends ApiGatewayHandler<String, String> {
+public class EchoHandler<I> extends ApiGatewayHandler<I, I> {
 
   private final List<InputObserver> observers;
 
-  protected EchoHandler(ObjectMapper objectMapper, InputObserver... observers) {
-    super(String.class, objectMapper);
+  protected EchoHandler(Class<I> iClass,
+    ObjectMapper objectMapper,
+    InputObserver... observers) {
+    super(iClass, objectMapper);
     this.observers = Arrays.asList(observers);
   }
 
   @Override
-  public String processInput(String body, ApiGatewayEvent apiGatewayEvent, Context context)
+  public I processInput(I body, ApiGatewayEvent apiGatewayEvent, Context context)
     throws ApiGatewayException {
     for (var observer : observers) {
       observer.observe(body);

--- a/apigateway/src/test/java/com/github/awsjavakit/apigateway/observers/BodyObserver.java
+++ b/apigateway/src/test/java/com/github/awsjavakit/apigateway/observers/BodyObserver.java
@@ -1,0 +1,15 @@
+package com.github.awsjavakit.apigateway.observers;
+
+public class BodyObserver<S> implements InputObserver {
+
+  private S body;
+
+  @Override
+  public <I> void observe(I body) {
+    this.body = (S) body;
+  }
+
+  public S getBody() {
+    return body;
+  }
+}

--- a/apigateway/src/test/java/com/github/awsjavakit/apigateway/observers/InputObserver.java
+++ b/apigateway/src/test/java/com/github/awsjavakit/apigateway/observers/InputObserver.java
@@ -1,5 +1,6 @@
-package com.github.awsjavakit.apigateway;
+package com.github.awsjavakit.apigateway.observers;
 
+import com.github.awsjavakit.apigateway.NotFoundException;
 import com.github.awsjavakit.apigateway.exception.ApiGatewayException;
 
 public interface InputObserver {
@@ -7,8 +8,8 @@ public interface InputObserver {
   static InputObserver noOp() {
     return new InputObserver() {
       @Override
-      public <I> void observe(I body) {
-        //NO-OP
+      public <I> void observe(I body) throws ApiGatewayException {
+        //NO-OP;
       }
     };
   }

--- a/apigateway/src/test/java/com/github/awsjavakit/apigateway/observers/InputObserver.java
+++ b/apigateway/src/test/java/com/github/awsjavakit/apigateway/observers/InputObserver.java
@@ -9,7 +9,7 @@ public interface InputObserver {
     return new InputObserver() {
       @Override
       public <I> void observe(I body) throws ApiGatewayException {
-        //NO-OP;
+        //NO-OP
       }
     };
   }

--- a/apigateway/src/test/java/com/github/awsjavakit/apigateway/observers/ThrowExceptionObserver.java
+++ b/apigateway/src/test/java/com/github/awsjavakit/apigateway/observers/ThrowExceptionObserver.java
@@ -1,4 +1,4 @@
-package com.github.awsjavakit.apigateway;
+package com.github.awsjavakit.apigateway.observers;
 
 import com.github.awsjavakit.apigateway.exception.ApiGatewayException;
 

--- a/buildSrc/src/main/groovy/com.github.awsjavakit.publishing.gradle
+++ b/buildSrc/src/main/groovy/com.github.awsjavakit.publishing.gradle
@@ -5,7 +5,7 @@ plugins {
 
 
 group = 'io.github.awsjavakit'
-version = '0.1.5'
+version = '0.1.6'
 
 java {
     withSourcesJar()


### PR DESCRIPTION
When receiving a GET HTTP request we will not have a request body. In these cases the body will be null. We should therefore be able to map the null object in the ApiGateway request  to a null input object. Example:
The following ApiGateway event should be translated a null input when the method ApiGatewayHandler#processInput method is called

```
{
  "body": null,
  "resource": "/{proxy+}",
  "path": "/path/to/resource",
  "httpMethod": "GET",
  "isBase64Encoded": true,
  "queryStringParameters": {
    "foo": "bar"
  }
  ...

```