### PR TITLE
builder sets body to null and not "null" when body is null

### DIFF
--- a/buildSrc/src/main/groovy/com.github.awsjavakit.publishing.gradle
+++ b/buildSrc/src/main/groovy/com.github.awsjavakit.publishing.gradle
@@ -5,7 +5,7 @@ plugins {
 
 
 group = 'io.github.awsjavakit'
-version = '0.3.3'
+version = '0.3.4'
 
 java {
     withSourcesJar()

--- a/testingutils/src/test/java/com/github/awsjavakit/testingutils/ApiGatewayRequestBuilderTest.java
+++ b/testingutils/src/test/java/com/github/awsjavakit/testingutils/ApiGatewayRequestBuilderTest.java
@@ -17,6 +17,12 @@ class ApiGatewayRequestBuilderTest {
 
   public static final String BODY_FIELD = "body";
   private static final ObjectMapper JSON = new ObjectMapper();
+  public static final String PATH_FIELD = "path";
+  public static final String QUERY_PARAMETERS_FIELD = "queryParameters";
+  public static final String HEADERS_FIELD = "headers";
+  public static final String MULTI_VALUE_HEADER_FIELD = "multiValueHeader";
+  public static final String METHOD_FIELD = "method";
+
 
   @Test
   void shouldGenerateValidEvent() throws JsonProcessingException {
@@ -36,8 +42,12 @@ class ApiGatewayRequestBuilderTest {
 
     assertThat(generatedDeserialized)
       .usingRecursiveComparison()
-      .comparingOnlyFields("path", BODY_FIELD, "queryParameters", "headers", "multiValueHeader",
-        "method")
+      .comparingOnlyFields(PATH_FIELD,
+        BODY_FIELD,
+        QUERY_PARAMETERS_FIELD,
+        HEADERS_FIELD,
+        MULTI_VALUE_HEADER_FIELD,
+        METHOD_FIELD)
       .isEqualTo(deserialized);
   }
 

--- a/testingutils/src/test/java/com/github/awsjavakit/testingutils/ApiGatewayRequestBuilderTest.java
+++ b/testingutils/src/test/java/com/github/awsjavakit/testingutils/ApiGatewayRequestBuilderTest.java
@@ -16,13 +16,12 @@ import org.junit.jupiter.api.Test;
 class ApiGatewayRequestBuilderTest {
 
   public static final String BODY_FIELD = "body";
-  private static final ObjectMapper JSON = new ObjectMapper();
   public static final String PATH_FIELD = "path";
   public static final String QUERY_PARAMETERS_FIELD = "queryParameters";
   public static final String HEADERS_FIELD = "headers";
   public static final String MULTI_VALUE_HEADER_FIELD = "multiValueHeader";
   public static final String METHOD_FIELD = "method";
-
+  private static final ObjectMapper JSON = new ObjectMapper();
 
   @Test
   void shouldGenerateValidEvent() throws JsonProcessingException {

--- a/testingutils/src/test/java/com/github/awsjavakit/testingutils/ApiGatewayRequestBuilderTest.java
+++ b/testingutils/src/test/java/com/github/awsjavakit/testingutils/ApiGatewayRequestBuilderTest.java
@@ -1,5 +1,6 @@
 package com.github.awsjavakit.testingutils;
 
+import static com.github.awsjavakit.testingutils.RandomDataGenerator.randomString;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -8,11 +9,13 @@ import com.github.awsjavakit.apigateway.ApiGatewayEvent;
 import com.github.awsjavakit.apigateway.HttpMethod;
 import com.github.awsjavakit.misc.ioutils.IoUtils;
 import com.github.awsjavakit.misc.paths.UnixPath;
+import java.io.IOException;
 import java.nio.file.Path;
 import org.junit.jupiter.api.Test;
 
 class ApiGatewayRequestBuilderTest {
 
+  public static final String BODY_FIELD = "body";
   private static final ObjectMapper JSON = new ObjectMapper();
 
   @Test
@@ -33,9 +36,47 @@ class ApiGatewayRequestBuilderTest {
 
     assertThat(generatedDeserialized)
       .usingRecursiveComparison()
-      .comparingOnlyFields("path", "body", "queryParameters", "headers", "multiValueHeader","method")
+      .comparingOnlyFields("path", BODY_FIELD, "queryParameters", "headers", "multiValueHeader",
+        "method")
       .isEqualTo(deserialized);
-
   }
 
+  @Test
+  void shouldWriteBodyAsIsWhenItIsString() throws IOException {
+    var expectedBodyContent = randomString();
+    var event = ApiGatewayRequestBuilder.create(JSON)
+      .withBody(expectedBodyContent)
+      .build();
+    var json = JSON.readTree(event);
+
+    assertThat(json.get(BODY_FIELD).isTextual()).isTrue();
+    assertThat(json.get(BODY_FIELD).asText()).isEqualTo(expectedBodyContent);
+  }
+
+  @Test
+  void shouldWriteBodyAsValidJsonStringWhenBodyIsAnObject() throws IOException {
+    var expectedBodyContent = new SampleInput(randomString(), randomString());
+    var event = ApiGatewayRequestBuilder.create(JSON)
+      .withBody(expectedBodyContent)
+      .build();
+    var json = JSON.readTree(event);
+    var bodyString = json.get(BODY_FIELD).textValue();
+    var deserializedBody = JSON.readValue(bodyString, SampleInput.class);
+
+    assertThat(json.get(BODY_FIELD).isTextual()).isTrue();
+    assertThat(deserializedBody).isEqualTo(expectedBodyContent);
+  }
+
+  @Test
+  void shouldSetBodyToNullWhenBodyIsNull() throws IOException {
+    var event = ApiGatewayRequestBuilder.create(JSON)
+      .withBody(null)
+      .build();
+    var json = JSON.readTree(event);
+    assertThat(json.get(BODY_FIELD).isNull()).isTrue();
+  }
+
+  private record SampleInput(String fieldA, String fieldB) {
+
+  }
 }


### PR DESCRIPTION
Currently when serializing a ApiGateway request with a null body, the serializer writes 
```
{...
"body": "null"
...
}
```
which is wrong. 
The desired functionality is 
```
{...
"body": null
...
}
```