### PR TITLE
Copy Secrets from NVA

### DIFF
--- a/buildSrc/src/main/groovy/com.github.awsjavakit.publishing.gradle
+++ b/buildSrc/src/main/groovy/com.github.awsjavakit.publishing.gradle
@@ -5,7 +5,7 @@ plugins {
 
 
 group = 'io.github.awsjavakit'
-version = '0.3.7'
+version = '0.3.8'
 
 java {
     withSourcesJar()

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -14,6 +14,7 @@ datafaker = { strictly = '1.9.0' }
 hamcrest = { strictly = '2.2' }
 hamcrestOptional = { strictly = '2.0.0' }
 wiremock = { strictly = '3.0.4' }
+mockito = { strictly = '5.5.0' }
 
 [libraries]
 
@@ -25,6 +26,8 @@ slf4j-binding = { group = 'org.apache.logging.log4j', name = 'log4j-slf4j18-impl
 lambda-log4j2 = { group = 'com.amazonaws', name = 'aws-lambda-java-log4j2', version.ref = 'lambda-log4j2' }
 
 aws-apigateway = { group = 'software.amazon.awssdk', name = 'apigateway', version.ref = 'awsSdk2' }
+aws-secrets = { group = 'software.amazon.awssdk', name = 'secretsmanager', version.ref = 'awsSdk2' }
+
 
 
 jackson-core = { group = 'com.fasterxml.jackson.core', name = 'jackson-core', version.ref = 'jackson' }
@@ -48,10 +51,12 @@ datafaker = { group = 'net.datafaker', name = 'datafaker', version.ref = 'datafa
 hamcrest = { group = 'org.hamcrest', name = 'hamcrest', version.ref = 'hamcrest' }
 hamcrest-optional = { group = 'com.github.npathai', name = 'hamcrest-optional', version.ref = 'hamcrestOptional' }
 wiremock = { group = 'org.wiremock', name = 'wiremock', version.ref = 'wiremock' }
+mockito-core = { group = 'org.mockito', name = 'mockito-core', version.ref = 'mockito' }
+mockito-junit = { group = 'org.mockito', name = 'mockito-junit-jupiter', version.ref = 'mockito' }
 
 
 [bundles]
-testing = ["junit-api", "junit-engine", "junit-params", "assertj", "commons-lang", "datafaker", "hamcrest","hamcrest-optional"]
+testing = ["junit-api", "junit-engine", "junit-params", "assertj", "commons-lang", "datafaker", "hamcrest", "hamcrest-optional", "mockito-core", "mockito-junit"]
 json = ['jackson-core', 'jackson-datatype-jdk8', 'jackson-databind', 'jackson-annotations']
 logging = ['log4j-core', 'slf4j', 'slf4j-binding', 'lambda-log4j2']
 

--- a/secrets/build.gradle
+++ b/secrets/build.gradle
@@ -1,0 +1,20 @@
+plugins {
+    id 'com.github.awsjavakit.java-library-conventions'
+    id 'com.github.awsjavakit.publishing'
+}
+
+
+dependencies {
+
+    implementation libs.lambda.core
+    implementation libs.aws.secrets
+    implementation libs.bundles.json
+    implementation project(":attempt")
+    implementation project(":misc")
+
+    testImplementation project(":testingutils")
+    testImplementation libs.bundles.testing
+
+
+
+}

--- a/secrets/src/main/java/com/githhub/awsjavakit/secrets/ErrorReadingSecretException.java
+++ b/secrets/src/main/java/com/githhub/awsjavakit/secrets/ErrorReadingSecretException.java
@@ -1,0 +1,17 @@
+package com.githhub.awsjavakit.secrets;
+
+public class ErrorReadingSecretException extends RuntimeException {
+
+  public ErrorReadingSecretException(String secretName, Throwable cause) {
+    super(errorMessage(secretName), cause);
+  }
+
+  public ErrorReadingSecretException(Throwable cause) {
+    super(cause);
+  }
+
+  private static String errorMessage(String secretName) {
+    return String.format("Could not read secret: %s", secretName);
+  }
+
+}

--- a/secrets/src/main/java/com/githhub/awsjavakit/secrets/ErrorReadingSecretException.java
+++ b/secrets/src/main/java/com/githhub/awsjavakit/secrets/ErrorReadingSecretException.java
@@ -6,12 +6,7 @@ public class ErrorReadingSecretException extends RuntimeException {
     super(errorMessage(secretName), cause);
   }
 
-  public ErrorReadingSecretException(Throwable cause) {
-    super(cause);
-  }
-
   private static String errorMessage(String secretName) {
     return String.format("Could not read secret: %s", secretName);
   }
-
 }

--- a/secrets/src/main/java/com/githhub/awsjavakit/secrets/SecretsReader.java
+++ b/secrets/src/main/java/com/githhub/awsjavakit/secrets/SecretsReader.java
@@ -1,0 +1,98 @@
+package com.githhub.awsjavakit.secrets;
+
+import static com.gtihub.awsjavakit.attempt.Try.attempt;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.gtihub.awsjavakit.attempt.Failure;
+import com.gtihub.awsjavakit.attempt.Try;
+
+import software.amazon.awssdk.services.secretsmanager.SecretsManagerClient;
+import software.amazon.awssdk.services.secretsmanager.model.GetSecretValueRequest;
+import software.amazon.awssdk.services.secretsmanager.model.GetSecretValueResponse;
+
+public class SecretsReader {
+
+  private final SecretsManagerClient awsSecretsManager;
+  private final ObjectMapper json;
+
+  public SecretsReader(SecretsManagerClient awsSecretsManager, ObjectMapper objectMapper) {
+    this.awsSecretsManager = awsSecretsManager;
+    this.json = objectMapper;
+  }
+
+  /**
+   * Fetches a secret String from AWS Secrets Manager.
+   *
+   * @param secretName the user-friendly id of the secret or the secret ARN
+   * @param secretKey  the key in the encrypted key-value map.
+   * @return the value for the specified key
+   * @throws ErrorReadingSecretException when any error occurs.
+   */
+  public String fetchSecret(String secretName, String secretKey) {
+
+    return attempt(() -> fetchSecretFromAws(secretName))
+      .map(fetchResult -> extractKey(fetchResult, secretKey, secretName))
+      .orElseThrow(fail->errorReadingSecret(fail,secretName,secretKey));
+  }
+
+
+
+  /**
+   * Fetches a plain-text secret from AWS Secrets Manager.
+   *
+   * @param secretName the user-friendly id of the secret or the secret ARN
+   * @return the plain text value for the specified secret name
+   * @throws ErrorReadingSecretException when any error occurs.
+   */
+  public String fetchPlainTextSecret(String secretName) {
+
+    return attempt(() -> fetchSecretFromAws(secretName))
+      .map(GetSecretValueResponse::secretString)
+      .orElseThrow(fail->errorReadingSecret(fail,secretName));
+  }
+
+  /**
+   * Fetches a json secret from AWS Secrets Manager as a class.
+   *
+   * @param secretName the user-friendly id of the secret or the secret ARN
+   * @param tclass     the class or interface of the class to be returned
+   * @param <T>        the type of the class or interface of the class to be returned
+   * @return Class of the object we want to extract the secret to
+   * @throws ErrorReadingSecretException when any error occurs.
+   */
+  public <T> T fetchClassSecret(String secretName, Class<T> tclass) {
+
+    return attempt(() -> fetchSecretFromAws(secretName))
+      .map(GetSecretValueResponse::secretString)
+      .map(str -> json.readValue(str, tclass))
+      .orElseThrow((Failure<T> fail) -> errorReadingSecret(fail, secretName));
+  }
+
+  private GetSecretValueResponse fetchSecretFromAws(String secretName) {
+    return awsSecretsManager
+      .getSecretValue(GetSecretValueRequest.builder().secretId(secretName).build());
+  }
+
+  private String extractKey(GetSecretValueResponse getSecretResult, String secretKey,
+    String secretName) {
+
+    return Try.of(getSecretResult)
+      .map(GetSecretValueResponse::secretString)
+      .flatMap(this::readStringAsJsonObject)
+      .map(secretJson -> secretJson.get(secretKey))
+      .map(JsonNode::textValue)
+      .orElseThrow((Failure<String> fail) -> errorReadingSecret(fail, secretName, secretKey));
+  }
+
+  private <T> ErrorReadingSecretException errorReadingSecret(Failure<T> fail,
+    String... secretDetails) {
+    var secretDetailsString = String.join(":", secretDetails);
+    return new ErrorReadingSecretException(secretDetailsString, fail.getException());
+  }
+
+  private Try<JsonNode> readStringAsJsonObject(String secretString) {
+    return attempt(() -> json.readTree(secretString));
+  }
+
+}

--- a/secrets/src/main/java/com/githhub/awsjavakit/secrets/SecretsReader.java
+++ b/secrets/src/main/java/com/githhub/awsjavakit/secrets/SecretsReader.java
@@ -13,6 +13,7 @@ import software.amazon.awssdk.services.secretsmanager.model.GetSecretValueRespon
 
 public class SecretsReader {
 
+  private static final String SECRET_NAME_KEY_DELIMITER = ":";
   private final SecretsManagerClient awsSecretsManager;
   private final ObjectMapper json;
 
@@ -87,7 +88,7 @@ public class SecretsReader {
 
   private <T> ErrorReadingSecretException errorReadingSecret(Failure<T> fail,
     String... secretDetails) {
-    var secretDetailsString = String.join(":", secretDetails);
+    var secretDetailsString = String.join(SECRET_NAME_KEY_DELIMITER, secretDetails);
     return new ErrorReadingSecretException(secretDetailsString, fail.getException());
   }
 

--- a/secrets/src/test/java/com/githhub/awsjavakit/secrets/Credentials.java
+++ b/secrets/src/test/java/com/githhub/awsjavakit/secrets/Credentials.java
@@ -1,0 +1,5 @@
+package com.githhub.awsjavakit.secrets;
+
+public record Credentials(String username, String password) {
+
+}

--- a/secrets/src/test/java/com/githhub/awsjavakit/secrets/SecretsReaderTest.java
+++ b/secrets/src/test/java/com/githhub/awsjavakit/secrets/SecretsReaderTest.java
@@ -1,0 +1,148 @@
+package com.githhub.awsjavakit.secrets;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsEqual.equalTo;
+import static org.hamcrest.core.IsNot.not;
+import static org.hamcrest.core.StringContains.containsString;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.Executable;
+import org.mockito.invocation.InvocationOnMock;
+import software.amazon.awssdk.services.secretsmanager.SecretsManagerClient;
+import software.amazon.awssdk.services.secretsmanager.model.GetSecretValueRequest;
+import software.amazon.awssdk.services.secretsmanager.model.GetSecretValueResponse;
+import software.amazon.awssdk.services.secretsmanager.model.ResourceNotFoundException;
+
+class SecretsReaderTest {
+
+  static final String SECRET_VALUE = "SECRET_VALUE";
+  static final String SECRET_KEY = "SECRET_KEY";
+  static final String SECRET_NAME = "SECRET_NAME";
+  static final String PLAIN_TEXT_SECRET_NAME = "PLAIN_TEXT_SECRET_NAME";
+  static final String PLAIN_TEXT_SECRET_VALUE = "PLAIN_TEXT_SECRET_VALUE";
+  static final String JSON_SECRET_NAME = "JSON_SECRET_NAME";
+  static final String JSON_SECRET_VALUE = "{\"username\":\"name\", \"password\":\"pass\"}";
+  static final String JSON_LIST_SECRET_NAME = "JSON_LIST_SECRET_NAME";
+  static final String JSON_LIST_SECRET_VALUE = "[{\"key1\":\"val1\"},{\"key1\":\"val2\"}]";
+  static final String JSON_SECRET_VALUE_USERNAME = "name";
+  static final String JSON_SECRET_VALUE_PASSWORD = "pass";
+  static final String WRONG_SECRET_NAME = "WRONG_SECRET_NAME";
+  static final String WRONG_SECRET_KEY = "WRONG_KEY";
+  private static final ObjectMapper JSON = new ObjectMapper();
+  private final SecretsReader secretsReader;
+
+  SecretsReaderTest() {
+    secretsReader = createSecretsReaderMock();
+  }
+
+  @Test
+  void shouldThrowExceptionContainingTheNonExistingSecretName() {
+    Executable action = () -> secretsReader.fetchSecret(WRONG_SECRET_NAME, SECRET_KEY);
+    var exception = assertThrows(ErrorReadingSecretException.class, action);
+    assertThat(exception.getMessage(), containsString(WRONG_SECRET_NAME));
+  }
+
+  @Test
+  void shouldThrowExceptionWhenWrongSecretKeyIsGiven() {
+    Executable action = () -> secretsReader.fetchSecret(SECRET_NAME, WRONG_SECRET_KEY);
+    var exception = assertThrows(ErrorReadingSecretException.class, action);
+    assertThat(exception.getMessage(), containsString(WRONG_SECRET_KEY));
+  }
+
+  @Test
+  void fetchSecretReturnsSecretValueWhenSecretNameAndSecretKeyAreCorrect()
+    throws ErrorReadingSecretException {
+    var value = secretsReader.fetchSecret(SECRET_NAME, SECRET_KEY);
+    assertThat(value, is(equalTo(SECRET_VALUE)));
+  }
+
+  @Test
+  void shouldReturnInputSecretAsInputClassWhenInputSecretExistsAndIsStructuredLikeInputSecretClass() {
+    var credentials = secretsReader.fetchClassSecret(JSON_SECRET_NAME, Credentials.class);
+    assertThat(credentials.username(), is(equalTo(JSON_SECRET_VALUE_USERNAME)));
+    assertThat(credentials.password(), is(equalTo(JSON_SECRET_VALUE_PASSWORD)));
+  }
+
+  @Test
+  void shouldNotExposeSecretInThrowWhenInputSecretExistsButIsPlaintext() {
+    Executable action = () -> secretsReader.fetchClassSecret(PLAIN_TEXT_SECRET_NAME,
+      Credentials.class);
+    var thrown = assertThrows(ErrorReadingSecretException.class, action);
+    assertThat(thrown.getMessage(), not(containsString(PLAIN_TEXT_SECRET_VALUE)));
+  }
+
+  @Test
+  void shouldNotExposeSecretInThrowWhenInputSecretExistsButIsJsonList() {
+    Executable action = () -> secretsReader.fetchClassSecret(JSON_LIST_SECRET_NAME,
+      Credentials.class);
+    var thrown = assertThrows(ErrorReadingSecretException.class, action);
+    assertThat(thrown.getMessage(), not(containsString(PLAIN_TEXT_SECRET_VALUE)));
+  }
+
+  @Test
+  void fetchPlainTextSecretWhenSecretNameIsCorrect() {
+    var value = secretsReader.fetchPlainTextSecret(PLAIN_TEXT_SECRET_NAME);
+    assertThat(value, is(equalTo(PLAIN_TEXT_SECRET_VALUE)));
+  }
+
+  @Test
+  void shouldSupplyWrongSecretNameWhenFetchingPlainTextAndWrongSecretNameIsGiven() {
+    Executable action = () -> secretsReader.fetchPlainTextSecret(WRONG_SECRET_NAME);
+    var exception = assertThrows(ErrorReadingSecretException.class, action);
+    assertThat(exception.getMessage(), containsString(WRONG_SECRET_NAME));
+  }
+
+  private SecretsReader createSecretsReaderMock() {
+    var secretsManager = mock(SecretsManagerClient.class);
+    when(secretsManager.getSecretValue(any(GetSecretValueRequest.class)))
+      .thenAnswer(this::provideGetSecretValueResult);
+    return new SecretsReader(secretsManager, JSON);
+  }
+
+  private GetSecretValueResponse provideGetSecretValueResult(InvocationOnMock invocation)
+    throws JsonProcessingException {
+    String providedSecretName = getSecretNameFromRequest(invocation);
+
+    switch (providedSecretName) {
+      case SECRET_NAME:
+        String secretString = createSecretJsonObject();
+        return createGetSecretValueResult(secretString);
+      case PLAIN_TEXT_SECRET_NAME:
+        return createGetSecretValueResult(PLAIN_TEXT_SECRET_VALUE);
+      case JSON_SECRET_NAME:
+        return createGetSecretValueResult(JSON_SECRET_VALUE);
+      case JSON_LIST_SECRET_NAME:
+        return createGetSecretValueResult(JSON_LIST_SECRET_VALUE);
+      default:
+        throw ResourceNotFoundException.create("Secret not found",
+          new RuntimeException("exception in mock"));
+    }
+
+  }
+
+  private String getSecretNameFromRequest(InvocationOnMock invocation) {
+    GetSecretValueRequest request = invocation.getArgument(0);
+    return request.secretId();
+  }
+
+  private GetSecretValueResponse createGetSecretValueResult(String secretString) {
+    return GetSecretValueResponse.builder()
+      .secretString(secretString)
+      .name(SECRET_NAME)
+      .build();
+  }
+
+  private String createSecretJsonObject() throws JsonProcessingException {
+    var secret = Map.of(SECRET_KEY, SECRET_VALUE);
+    return JSON.writeValueAsString(secret);
+  }
+
+}

--- a/secrets/src/test/java/com/githhub/awsjavakit/secrets/SecretsReaderTest.java
+++ b/secrets/src/test/java/com/githhub/awsjavakit/secrets/SecretsReaderTest.java
@@ -5,7 +5,7 @@ import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.hamcrest.core.IsNot.not;
 import static org.hamcrest.core.StringContains.containsString;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -58,8 +58,7 @@ class SecretsReaderTest {
   }
 
   @Test
-  void fetchSecretReturnsSecretValueWhenSecretNameAndSecretKeyAreCorrect()
-    throws ErrorReadingSecretException {
+  void fetchSecretReturnsSecretValueWhenSecretNameAndSecretKeyAreCorrect() {
     var value = secretsReader.fetchSecret(SECRET_NAME, SECRET_KEY);
     assertThat(value, is(equalTo(SECRET_VALUE)));
   }

--- a/settings.gradle
+++ b/settings.gradle
@@ -6,5 +6,6 @@ plugins {
 rootProject.name = 'aws-java-kit'
 include('attempt')
 include('apigateway')
+include('secrets')
 include('misc')
 include('testingutils')

--- a/testingutils/build.gradle
+++ b/testingutils/build.gradle
@@ -8,11 +8,15 @@ dependencies {
     compileOnly project(":apigateway")
     implementation project (":attempt")
     implementation project (":misc")
-    testImplementation project (":apigateway")
+
     implementation libs.lambda.core
     implementation libs.aws.apigateway
+    implementation libs.aws.secrets
     implementation libs.bundles.json
     implementation libs.bundles.testing
+
+    testImplementation project (":apigateway")
+    testImplementation project (":secrets")
     testImplementation libs.wiremock
 
 }

--- a/testingutils/src/main/java/com/github/awsjavakit/testingutils/aws/FakeSecretsManagerClient.java
+++ b/testingutils/src/main/java/com/github/awsjavakit/testingutils/aws/FakeSecretsManagerClient.java
@@ -2,7 +2,7 @@ package com.github.awsjavakit.testingutils.aws;
 
 /**
  * Copied from https://github.com/BIBSYSDEV/nva-commons.
- * */
+ */
 
 import static com.gtihub.awsjavakit.attempt.Try.attempt;
 
@@ -20,11 +20,11 @@ import software.amazon.awssdk.services.secretsmanager.model.GetSecretValueRespon
 
 public class FakeSecretsManagerClient implements SecretsManagerClient {
 
+  private final Map<SecretName, Map<SecretKey, String>> secrets = new ConcurrentHashMap<>();
   private final Map<SecretName, String> plainTextSecrets = new ConcurrentHashMap<>();
   private final ObjectMapper json;
-  public Map<SecretName, Map<SecretKey, String>> secrets = new ConcurrentHashMap<>();
 
-  public FakeSecretsManagerClient(ObjectMapper json){
+  public FakeSecretsManagerClient(ObjectMapper json) {
     this.json = json;
   }
 
@@ -46,7 +46,8 @@ public class FakeSecretsManagerClient implements SecretsManagerClient {
   public FakeSecretsManagerClient putPlainTextSecret(String name, String value) {
     var secretName = new SecretName(name);
     if (secrets.containsKey(secretName)) {
-      throw new IllegalArgumentException(String.format("Secret already present as a key/value secret: %s", name));
+      throw new IllegalArgumentException(
+        String.format("Secret already present as a key/value secret: %s", name));
     }
 
     plainTextSecrets.put(secretName, value);
@@ -71,7 +72,7 @@ public class FakeSecretsManagerClient implements SecretsManagerClient {
   @JacocoGenerated
   @Override
   public void close() {
-
+    //NO-OP
   }
 
   private static GetSecretValueResponse addSecretContents(String secretContents,
@@ -106,7 +107,7 @@ public class FakeSecretsManagerClient implements SecretsManagerClient {
     secrets.get(secretName).put(new SecretKey(key), value);
   }
 
-  private static class SecretName {
+  private static final class SecretName {
 
     private final String value;
 
@@ -124,7 +125,7 @@ public class FakeSecretsManagerClient implements SecretsManagerClient {
     @JacocoGenerated
     @Override
     public int hashCode() {
-      return value != null ? value.hashCode() : 0;
+      return value == null ? 0 : value.hashCode();
     }
 
     @JacocoGenerated
@@ -143,7 +144,7 @@ public class FakeSecretsManagerClient implements SecretsManagerClient {
     }
   }
 
-  private static class SecretKey {
+  private static final class SecretKey {
 
     private final String value;
 
@@ -160,7 +161,7 @@ public class FakeSecretsManagerClient implements SecretsManagerClient {
     @JacocoGenerated
     @Override
     public int hashCode() {
-      return value != null ? value.hashCode() : 0;
+      return value == null ? 0 : value.hashCode();
     }
 
     @JacocoGenerated

--- a/testingutils/src/main/java/com/github/awsjavakit/testingutils/aws/FakeSecretsManagerClient.java
+++ b/testingutils/src/main/java/com/github/awsjavakit/testingutils/aws/FakeSecretsManagerClient.java
@@ -1,0 +1,181 @@
+package com.github.awsjavakit.testingutils.aws;
+
+/**
+ * Copied from https://github.com/BIBSYSDEV/nva-commons.
+ * */
+
+import static com.gtihub.awsjavakit.attempt.Try.attempt;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.awsjavakit.misc.JacocoGenerated;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import software.amazon.awssdk.services.secretsmanager.SecretsManagerClient;
+import software.amazon.awssdk.services.secretsmanager.model.GetSecretValueRequest;
+import software.amazon.awssdk.services.secretsmanager.model.GetSecretValueResponse;
+
+public class FakeSecretsManagerClient implements SecretsManagerClient {
+
+  private final Map<SecretName, String> plainTextSecrets = new ConcurrentHashMap<>();
+  private final ObjectMapper json;
+  public Map<SecretName, Map<SecretKey, String>> secrets = new ConcurrentHashMap<>();
+
+  public FakeSecretsManagerClient(ObjectMapper json){
+    this.json = json;
+  }
+
+  public FakeSecretsManagerClient putSecret(String name, String key, String value) {
+    var secretName = new SecretName(name);
+    if (plainTextSecrets.containsKey(secretName)) {
+      throw new IllegalArgumentException(
+        String.format("Secret already present as a plain text secret: %s", name));
+    }
+
+    if (secrets.containsKey(secretName)) {
+      addSecretValueToExistingSecret(key, value, secretName);
+    } else {
+      createNewSecret(key, value, secretName);
+    }
+    return this;
+  }
+
+  public FakeSecretsManagerClient putPlainTextSecret(String name, String value) {
+    var secretName = new SecretName(name);
+    if (secrets.containsKey(secretName)) {
+      throw new IllegalArgumentException(String.format("Secret already present as a key/value secret: %s", name));
+    }
+
+    plainTextSecrets.put(secretName, value);
+    return this;
+  }
+
+  @Override
+  public GetSecretValueResponse getSecretValue(GetSecretValueRequest getSecretValueRequest) {
+    return Optional.ofNullable(getSecretValueRequest.secretId())
+      .map(SecretName::new)
+      .flatMap(this::resolveSecret)
+      .map(secretContents -> addSecretContents(secretContents, getSecretValueRequest))
+      .orElseThrow();
+  }
+
+  @JacocoGenerated
+  @Override
+  public String serviceName() {
+    return null;
+  }
+
+  @JacocoGenerated
+  @Override
+  public void close() {
+
+  }
+
+  private static GetSecretValueResponse addSecretContents(String secretContents,
+    GetSecretValueRequest getSecretValueRequest) {
+    return GetSecretValueResponse.builder()
+      .secretString(secretContents)
+      .name(getSecretValueRequest.secretId())
+      .build();
+  }
+
+  private String serializeSecretContents(Map<SecretKey, String> secretContents) {
+    return attempt(() -> json.writeValueAsString(secretContents)).orElseThrow();
+  }
+
+  private Optional<String> resolveSecret(SecretName secretName) {
+    if (secrets.containsKey(secretName)) {
+      return Optional.of(serializeSecretContents(secrets.get(secretName)));
+    } else if (plainTextSecrets.containsKey(secretName)) {
+      return Optional.of(plainTextSecrets.get(secretName));
+    } else {
+      return Optional.empty();
+    }
+  }
+
+  private void createNewSecret(String key, String value, SecretName secretName) {
+    ConcurrentHashMap<SecretKey, String> secretContents = new ConcurrentHashMap<>();
+    secretContents.put(new SecretKey(key), value);
+    secrets.put(secretName, secretContents);
+  }
+
+  private void addSecretValueToExistingSecret(String key, String value, SecretName secretName) {
+    secrets.get(secretName).put(new SecretKey(key), value);
+  }
+
+  private static class SecretName {
+
+    private final String value;
+
+    @JsonCreator
+    private SecretName(String value) {
+      this.value = value;
+    }
+
+    @JacocoGenerated
+    @JsonValue
+    public String getValue() {
+      return value;
+    }
+
+    @JacocoGenerated
+    @Override
+    public int hashCode() {
+      return value != null ? value.hashCode() : 0;
+    }
+
+    @JacocoGenerated
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (!(o instanceof SecretName)) {
+        return false;
+      }
+
+      SecretName that = (SecretName) o;
+
+      return Objects.equals(value, that.value);
+    }
+  }
+
+  private static class SecretKey {
+
+    private final String value;
+
+    @JsonCreator
+    public SecretKey(String value) {
+      this.value = value;
+    }
+
+    @JsonValue
+    public String getValue() {
+      return value;
+    }
+
+    @JacocoGenerated
+    @Override
+    public int hashCode() {
+      return value != null ? value.hashCode() : 0;
+    }
+
+    @JacocoGenerated
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (!(o instanceof SecretKey)) {
+        return false;
+      }
+
+      SecretKey secretKey = (SecretKey) o;
+
+      return Objects.equals(value, secretKey.value);
+    }
+  }
+}

--- a/testingutils/src/test/java/com/github/awsjavakit/testingutils/aws/FakeSecretsManagerClientTest.java
+++ b/testingutils/src/test/java/com/github/awsjavakit/testingutils/aws/FakeSecretsManagerClientTest.java
@@ -1,0 +1,78 @@
+package com.github.awsjavakit.testingutils.aws;
+
+import static com.github.awsjavakit.testingutils.RandomDataGenerator.randomString;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.githhub.awsjavakit.secrets.SecretsReader;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.Executable;
+
+class FakeSecretsManagerClientTest {
+
+  private final ObjectMapper JSON = new ObjectMapper();
+
+  @Test
+  void shouldBeUsableWithSecretsReader() {
+    var secretName = randomString();
+    var secretKey1 = randomString();
+    var secretValue1 = randomString();
+    var secretKey2 = randomString();
+    var secretValue2 = randomString();
+
+    var secretsClient =
+      new FakeSecretsManagerClient(JSON)
+        .putSecret(secretName, secretKey1, secretValue1)
+        .putSecret(secretName, secretKey2, secretValue2);
+    var secretsReader = new SecretsReader(secretsClient, JSON);
+    assertThat(secretsReader.fetchSecret(secretName, secretKey1), is(equalTo(secretValue1)));
+    assertThat(secretsReader.fetchSecret(secretName, secretKey2), is(equalTo(secretValue2)));
+  }
+
+  @Test
+  void shouldBeUsableWithSecretsReaderUsingPlainText() {
+    var plainTextSecretName = randomString();
+    var plainTextSecretValue = randomString();
+
+    var secretsClient =
+      new FakeSecretsManagerClient(JSON).putPlainTextSecret(plainTextSecretName,
+        plainTextSecretValue);
+    var secretsReader = new SecretsReader(secretsClient, JSON);
+
+    String secretValue = secretsReader.fetchPlainTextSecret(plainTextSecretName);
+    assertThat(secretValue, is(equalTo(plainTextSecretValue)));
+  }
+
+  @Test
+  void shouldThrowExceptionWhenTryingToAddPlainTextSecretWithSameNameAsExistingKeyValueSecret() {
+    var secretName = randomString();
+    var secretKey = randomString();
+    var secretValue = randomString();
+
+    try (var secretsClient = new FakeSecretsManagerClient(JSON)) {
+      secretsClient.putSecret(secretName, secretKey, secretValue);
+
+      Executable action = () -> secretsClient.putPlainTextSecret(secretName, secretValue);
+      assertThrows(IllegalArgumentException.class, action);
+    }
+  }
+
+  @Test
+  void shouldThrowExceptionWhenTryingToAddKeyValueSecretWithSameNameAsExistingPlainTextSecret() {
+    var secretName = randomString();
+    var secretKey = randomString();
+    var secretValue = randomString();
+
+    try (var secretsClient = new FakeSecretsManagerClient(JSON)) {
+      secretsClient.putPlainTextSecret(secretName, secretValue);
+
+      Executable action = () -> secretsClient.putSecret(secretName, secretKey, secretValue);
+      assertThrows(IllegalArgumentException.class, action);
+    }
+  }
+}
+
+

--- a/testingutils/src/test/java/com/github/awsjavakit/testingutils/aws/FakeSecretsManagerClientTest.java
+++ b/testingutils/src/test/java/com/github/awsjavakit/testingutils/aws/FakeSecretsManagerClientTest.java
@@ -4,7 +4,7 @@ import static com.github.awsjavakit.testingutils.RandomDataGenerator.randomStrin
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.githhub.awsjavakit.secrets.SecretsReader;
@@ -13,7 +13,7 @@ import org.junit.jupiter.api.function.Executable;
 
 class FakeSecretsManagerClientTest {
 
-  private final ObjectMapper JSON = new ObjectMapper();
+  private static final ObjectMapper JSON = new ObjectMapper();
 
   @Test
   void shouldBeUsableWithSecretsReader() {


### PR DESCRIPTION
Copy paste code with 2 exceptions:
 1. changed the names of some tests.
 2. The SecretsReader did not reveal the name of the secret it failed to read. Now we throw an exception that does reveal the secret name. This should be handled and never returned leeked to the service (e.g. API) user 