### PR TITLE
Allow non standard oauth endpoints

### DIFF
--- a/buildSrc/src/main/groovy/com.github.awsjavakit.java-common-conventions.gradle
+++ b/buildSrc/src/main/groovy/com.github.awsjavakit.java-common-conventions.gradle
@@ -7,7 +7,7 @@ plugins {
 
 
 group 'io.github.awsjavakit'
-version = '0.4.7'
+version = '0.5.0'
 
 repositories {
   mavenCentral()

--- a/http/src/main/java/com/github/awsjavakit/http/NewTokenProvider.java
+++ b/http/src/main/java/com/github/awsjavakit/http/NewTokenProvider.java
@@ -57,7 +57,7 @@ public class NewTokenProvider implements TokenProvider {
   }
 
   private HttpRequest formatRequestForOauth2Token() {
-    return HttpRequest.newBuilder(credentialsProvider.getAuthorizationEndpoint())
+    return HttpRequest.newBuilder(credentialsProvider.getAuthEndpointUri())
       .header(AUTHORIZATION_HEADER, credentialsProvider.getAuthorizationHeader())
       .header(CONTENT_TYPE_HEADER, APPLICATION_X_WWW_FORM_URLENCODED)
       .POST(clientCredentialsInXWwwFormUrlEncodedBody())

--- a/http/src/main/java/com/github/awsjavakit/http/NewTokenProvider.java
+++ b/http/src/main/java/com/github/awsjavakit/http/NewTokenProvider.java
@@ -57,7 +57,7 @@ public class NewTokenProvider implements TokenProvider {
   }
 
   private HttpRequest formatRequestForOauth2Token() {
-    return HttpRequest.newBuilder(credentialsProvider.getAuthEndpointUri())
+    return HttpRequest.newBuilder(credentialsProvider.getAuthEndpoint())
       .header(AUTHORIZATION_HEADER, credentialsProvider.getAuthorizationHeader())
       .header(CONTENT_TYPE_HEADER, APPLICATION_X_WWW_FORM_URLENCODED)
       .POST(clientCredentialsInXWwwFormUrlEncodedBody())

--- a/http/src/main/java/com/github/awsjavakit/http/NewTokenProvider.java
+++ b/http/src/main/java/com/github/awsjavakit/http/NewTokenProvider.java
@@ -57,7 +57,7 @@ public class NewTokenProvider implements TokenProvider {
   }
 
   private HttpRequest formatRequestForOauth2Token() {
-    return HttpRequest.newBuilder(credentialsProvider.getAuthEndpoint())
+    return HttpRequest.newBuilder(credentialsProvider.getAuthorizationEndpoint())
       .header(AUTHORIZATION_HEADER, credentialsProvider.getAuthorizationHeader())
       .header(CONTENT_TYPE_HEADER, APPLICATION_X_WWW_FORM_URLENCODED)
       .POST(clientCredentialsInXWwwFormUrlEncodedBody())

--- a/http/src/main/java/com/github/awsjavakit/http/OAuth2CredentialsFromSecretsManager.java
+++ b/http/src/main/java/com/github/awsjavakit/http/OAuth2CredentialsFromSecretsManager.java
@@ -33,7 +33,9 @@ public class OAuth2CredentialsFromSecretsManager implements OAuthCredentialsProv
   }
 
   @Override
-  public URI getAuthServerUri() {
-    return credentials.serverUri();
+  public URI getAuthEndpointUri() {
+    return credentials.authEndpointUri();
   }
+
+
 }

--- a/http/src/main/java/com/github/awsjavakit/http/OAuth2CredentialsFromSecretsManager.java
+++ b/http/src/main/java/com/github/awsjavakit/http/OAuth2CredentialsFromSecretsManager.java
@@ -33,7 +33,7 @@ public class OAuth2CredentialsFromSecretsManager implements OAuthCredentialsProv
   }
 
   @Override
-  public URI getAuthEndpoint() {
+  public URI getAuthorizationEndpoint() {
     return credentials.authEndpointUri();
   }
 

--- a/http/src/main/java/com/github/awsjavakit/http/OAuth2CredentialsFromSecretsManager.java
+++ b/http/src/main/java/com/github/awsjavakit/http/OAuth2CredentialsFromSecretsManager.java
@@ -33,7 +33,7 @@ public class OAuth2CredentialsFromSecretsManager implements OAuthCredentialsProv
   }
 
   @Override
-  public URI getAuthEndpointUri() {
+  public URI getAuthEndpoint() {
     return credentials.authEndpointUri();
   }
 

--- a/http/src/main/java/com/github/awsjavakit/http/OAuthCredentialsProvider.java
+++ b/http/src/main/java/com/github/awsjavakit/http/OAuthCredentialsProvider.java
@@ -13,7 +13,7 @@ public interface OAuthCredentialsProvider {
 
   String getClientSecret();
 
-  URI getAuthEndpointUri();
+  URI getAuthorizationEndpoint();
 
   default String getAuthorizationHeader(){
     return "Basic " + Base64.getEncoder().encodeToString(formatCredentialsForBasicAuth());

--- a/http/src/main/java/com/github/awsjavakit/http/OAuthCredentialsProvider.java
+++ b/http/src/main/java/com/github/awsjavakit/http/OAuthCredentialsProvider.java
@@ -1,6 +1,5 @@
 package com.github.awsjavakit.http;
 
-import com.github.awsjavakit.misc.paths.UriWrapper;
 import java.net.URI;
 import java.util.Base64;
 
@@ -9,16 +8,12 @@ import java.util.Base64;
  * a successful OAuth2 authentication handshake for the "grant_type" "client_credentials".
  */
 public interface OAuthCredentialsProvider {
-  String OAUTH2_TOKEN_PATH = "/oauth2/token";
+
   String getClientId();
 
   String getClientSecret();
 
-  URI getAuthServerUri();
-
-  default URI getAuthorizationEndpoint(){
-    return UriWrapper.fromUri(getAuthServerUri()).addChild(OAUTH2_TOKEN_PATH).getUri();
-  }
+  URI getAuthEndpointUri();
 
   default String getAuthorizationHeader(){
     return "Basic " + Base64.getEncoder().encodeToString(formatCredentialsForBasicAuth());

--- a/http/src/main/java/com/github/awsjavakit/http/Oauth2Credentials.java
+++ b/http/src/main/java/com/github/awsjavakit/http/Oauth2Credentials.java
@@ -2,6 +2,7 @@ package com.github.awsjavakit.http;
 
 import static com.gtihub.awsjavakit.attempt.Try.attempt;
 
+import com.fasterxml.jackson.annotation.JsonAlias;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.annotation.JsonTypeInfo.Id;
@@ -12,13 +13,13 @@ import java.net.URI;
  * Structure containing all the necessary information for an OAuth2 authentication handshake with
  * for grant_type "client_credentials".
  *
- * @param serverUri    the URI of the authentication server (without the "/oauth2/token" path)
+ * @param authEndpointUri    the URI of the authentication endpoint (e.g. "https://auth.example.com/oauth2/token")
  * @param clientId     the client id (username)
  * @param clientSecret the client secret (password)
  */
 @JsonTypeInfo(use = Id.NAME, property = "type")
 public record Oauth2Credentials(
-  @JsonProperty("serverUri") URI serverUri,
+  @JsonAlias("serverUri") @JsonProperty("authEndpointUri")  URI authEndpointUri,
   @JsonProperty("clientId") String clientId,
   @JsonProperty("clientSecret") String clientSecret) {
 

--- a/http/src/test/java/com/github/awsjavakit/http/RenewTokenWithCredentialsStoredInSecretsManagerTest.java
+++ b/http/src/test/java/com/github/awsjavakit/http/RenewTokenWithCredentialsStoredInSecretsManagerTest.java
@@ -1,7 +1,6 @@
 package com.github.awsjavakit.http;
 
 import static com.github.awsjavakit.http.OAuth2HttpClient.AUTHORIZATION_HEADER;
-import static com.github.awsjavakit.http.OAuthCredentialsProvider.OAUTH2_TOKEN_PATH;
 import static com.github.awsjavakit.testingutils.RandomDataGenerator.randomString;
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.post;
@@ -29,6 +28,7 @@ class RenewTokenWithCredentialsStoredInSecretsManagerTest {
   public static final ObjectMapper JSON = new ObjectMapper();
   public static final String SECURED_ENDPOINT_PATH = "/secured/endpoint";
   public static final String SECRET_NAME = "oauthCredentials";
+  private static final String OAUTH2_TOKEN_PATH = "/oauth2/token";
   private WireMockServer server;
   private URI serverUri;
   private String accessToken;
@@ -69,7 +69,8 @@ class RenewTokenWithCredentialsStoredInSecretsManagerTest {
 
 
   private void persistSecretsInSecretsManager() {
-    var oauthCredentials = new Oauth2Credentials(serverUri, clientId, clientSecret);
+    var authEndpoint = UriWrapper.fromUri(serverUri).addChild(OAUTH2_TOKEN_PATH).getUri();
+    var oauthCredentials = new Oauth2Credentials(authEndpoint, clientId, clientSecret);
     secretsClient.putPlainTextSecret(SECRET_NAME, oauthCredentials.toJsonString(JSON));
   }
 


### PR DESCRIPTION
### Current Situation Description:

In the current situation when we are supplying OAuth Credentials, we are supplying 
1. the Host Server URI (`https://auth.example.org`)
2. the clienItd 
3. the clientSecret. 

Then TokenProvider the requests a new token from the path "/oauth2/token" which is the standard path.  This means that the request will be sent to the URI `https://auth.example.org/oauth2/token`. 

### Problem description:
This creates problems when the auth server has a different auth endpoint (e.g. `/oauth/token`).

### Change description:
With this change, we assume that when we are supplying OAuthCredentials we are supplying the following:
1. The full URI for the auth endpoint (e.g. `https://auth.example.org/oauth2/token`)
2. the clientId
3. the clientSecret.

### Consequences:
All OAuthCredentials must be updated to include the full OAuth path.