### PR TITLE
Add strategy to avoid collisions when updating the access token

### DIFF
--- a/http/src/main/java/com/github/awsjavakit/http/NewTokenProvider.java
+++ b/http/src/main/java/com/github/awsjavakit/http/NewTokenProvider.java
@@ -21,7 +21,6 @@ import java.util.Map;
  */
 public class NewTokenProvider implements TokenProvider {
 
-  public static final String JWT_TOKEN_FIELD = "access_token";
   private static final String DUMMY_HOST = "notimportant";
 
   private static final Map<String, String> GRANT_TYPE_CLIENT_CREDENTIALS = Map.of("grant_type",

--- a/http/src/main/java/com/github/awsjavakit/http/ParameterStoreCachedTokenProvider.java
+++ b/http/src/main/java/com/github/awsjavakit/http/ParameterStoreCachedTokenProvider.java
@@ -1,15 +1,11 @@
 package com.github.awsjavakit.http;
 
+import static com.github.awsjavakit.http.JsonConfig.fromJson;
+import static com.github.awsjavakit.http.JsonConfig.toJson;
 import static com.gtihub.awsjavakit.attempt.Try.attempt;
-import static java.time.Instant.now;
-import static java.util.Objects.isNull;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.awsjavakit.http.token.OAuthTokenEntry;
-import java.time.Duration;
-import java.time.Instant;
-import java.util.Random;
-import java.util.UUID;
+import com.github.awsjavakit.http.updatestrategies.TokenCacheUpdateStrategy;
 import software.amazon.awssdk.services.ssm.SsmClient;
 import software.amazon.awssdk.services.ssm.model.GetParameterRequest;
 import software.amazon.awssdk.services.ssm.model.GetParameterResponse;
@@ -20,59 +16,36 @@ public class ParameterStoreCachedTokenProvider implements TokenProvider {
 
   public static final String DATATYPE = "text";
   public static final String TIER = "Standard";
-  public static final int MINIMUM_SLEEP_AMOUNT = 100;
-  public static final int SOME_LONG_ENOUGH_PERIOD = 400;
   private final TokenProvider newTokenProvider;
-  private final Duration maxTokenAge;
   private final SsmClient ssmClient;
-  private final ObjectMapper objectMapper;
   private final String parameterName;
+  private final TokenCacheUpdateStrategy<OAuthTokenEntry> updateStrategy;
 
   public ParameterStoreCachedTokenProvider(TokenProvider newTokenProvider,
     String ssmParameterName,
     SsmClient ssmClient,
-    Duration maxTokenAge,
-    ObjectMapper objectMapper) {
+    TokenCacheUpdateStrategy<OAuthTokenEntry> updateStrategy) {
     this.ssmClient = ssmClient;
     this.newTokenProvider = newTokenProvider;
-    this.maxTokenAge = maxTokenAge;
-    this.objectMapper = objectMapper;
     this.parameterName = ssmParameterName;
+    this.updateStrategy = updateStrategy;
   }
 
   @Override
   public OAuthTokenEntry fetchToken() {
-    var now = now();
-    var token = fetchTokenFromSsm();
-    if (thereIsNoValidToken(token, now)) {
-      var newValue = newTokenProvider.fetchToken();
-      token = storeNewToken(newValue);
-    }
+    return updateStrategy.fetchAndUpdate(this::updateToken, this::fetchTokenFromSsm);
+  }
+
+  private OAuthTokenEntry updateToken() {
+    OAuthTokenEntry token;
+    var newValue = newTokenProvider.fetchToken();
+    token = storeNewToken(newValue);
     return token;
-  }
-
-  private static void someOtherProcessMightBeGeneratingAToken() {
-    long seed = UUID.randomUUID().hashCode();
-    try {
-      Thread.sleep(MINIMUM_SLEEP_AMOUNT +new Random(seed).nextLong(SOME_LONG_ENOUGH_PERIOD));
-    } catch (InterruptedException e) {
-      throw new RuntimeException(e);
-    }
-  }
-
-  private Boolean thereIsNoValidToken(OAuthTokenEntry token, Instant now) {
-    return isNull(token) || now.isAfter(token.timestamp().plus(maxTokenAge));
   }
 
   private OAuthTokenEntry fetchTokenFromSsm() {
     var request = creteRequest();
-    var token = attemptToFetchToken(request);
-    if (thereIsNoValidToken(token, now())) {
-      someOtherProcessMightBeGeneratingAToken();
-      token = attemptToFetchToken(request);
-    }
-    return token;
-
+    return attemptToFetchToken(request);
   }
 
   private GetParameterRequest creteRequest() {
@@ -85,12 +58,8 @@ public class ParameterStoreCachedTokenProvider implements TokenProvider {
     return attempt(() -> ssmClient.getParameter(request))
       .map(GetParameterResponse::parameter)
       .map(Parameter::value)
-      .map(this::fromJson)
+      .map(json -> fromJson(json, OAuthTokenEntry.class))
       .orElse(fail -> null);
-  }
-
-  private OAuthTokenEntry fromJson(String json) {
-    return attempt(() -> objectMapper.readValue(json, OAuthTokenEntry.class)).orElseThrow();
   }
 
   private OAuthTokenEntry storeNewToken(OAuthTokenEntry token) {
@@ -104,7 +73,4 @@ public class ParameterStoreCachedTokenProvider implements TokenProvider {
     return token;
   }
 
-  private String toJson(OAuthTokenEntry tokenEntry) {
-    return attempt(() -> objectMapper.writeValueAsString(tokenEntry)).orElseThrow();
-  }
 }

--- a/http/src/main/java/com/github/awsjavakit/http/ParameterStoreCachedTokenProvider.java
+++ b/http/src/main/java/com/github/awsjavakit/http/ParameterStoreCachedTokenProvider.java
@@ -33,17 +33,17 @@ public class ParameterStoreCachedTokenProvider implements TokenProvider {
 
   @Override
   public OAuthTokenEntry fetchToken() {
-    return updateStrategy.fetchAndUpdate(this::updateToken, this::fetchTokenFromSsm);
+    return updateStrategy.fetchAndUpdate(this::fetchCachedEntry, this::updateCacheEntry);
   }
 
-  private OAuthTokenEntry updateToken() {
+  private OAuthTokenEntry updateCacheEntry() {
     OAuthTokenEntry token;
     var newValue = newTokenProvider.fetchToken();
     token = storeNewToken(newValue);
     return token;
   }
 
-  private OAuthTokenEntry fetchTokenFromSsm() {
+  private OAuthTokenEntry fetchCachedEntry() {
     var request = creteRequest();
     return attemptToFetchToken(request);
   }

--- a/http/src/main/java/com/github/awsjavakit/http/TokenProvider.java
+++ b/http/src/main/java/com/github/awsjavakit/http/TokenProvider.java
@@ -9,6 +9,7 @@ public interface TokenProvider {
   /**
    * Creates a TokenProvider that every time it fetches a Bearer token, it requests the generation o
    * of a new token
+   *
    * @param httpClient
    * @param authCredentialsProvider
    * @return
@@ -24,13 +25,9 @@ public interface TokenProvider {
     OAuthCredentialsProvider authCredentialsProvider,
     Duration maxTokenAge) {
     var tokenRefresher =
-      NewTokenProvider.create(httpClient,authCredentialsProvider);
-    return new CachedTokenProvider(tokenRefresher,maxTokenAge);
+      NewTokenProvider.create(httpClient, authCredentialsProvider);
+    return new CachedTokenProvider(tokenRefresher, maxTokenAge);
   }
 
-
   OAuthTokenEntry fetchToken();
-
-
-
 }

--- a/http/src/main/java/com/github/awsjavakit/http/token/OAuthTokenEntry.java
+++ b/http/src/main/java/com/github/awsjavakit/http/token/OAuthTokenEntry.java
@@ -27,4 +27,8 @@ public record OAuthTokenEntry(
   public String type() {
     return TYPE;
   }
+
+  public boolean hasExpired() {
+    return Instant.now().isAfter(expiration);
+  }
 }

--- a/http/src/main/java/com/github/awsjavakit/http/token/OAuthTokenResponse.java
+++ b/http/src/main/java/com/github/awsjavakit/http/token/OAuthTokenResponse.java
@@ -12,7 +12,7 @@ public class OAuthTokenResponse {
   @JsonProperty("access_token")
   private String accessToken;
   @JsonProperty("expires_in")
-  private Long durationInSeconds;
+  private Long validityPeriodInSeconds;
   private Instant timestamp;
 
   public OAuthTokenResponse() {
@@ -22,7 +22,7 @@ public class OAuthTokenResponse {
   public OAuthTokenResponse(String accessToken, long durationInSeconds) {
     this();
     this.accessToken = accessToken;
-    this.durationInSeconds = durationInSeconds;
+    this.validityPeriodInSeconds = durationInSeconds;
   }
 
   public Instant getTimestamp() {
@@ -37,16 +37,16 @@ public class OAuthTokenResponse {
     this.accessToken = accessToken;
   }
 
-  public Long getDurationInSeconds() {
-    return durationInSeconds;
+  public Long getValidityPeriodInSeconds() {
+    return validityPeriodInSeconds;
   }
 
-  public void setDurationInSeconds(Long durationInSeconds) {
-    this.durationInSeconds = durationInSeconds;
+  public void setValidityPeriodInSeconds(Long validityPeriodInSeconds) {
+    this.validityPeriodInSeconds = validityPeriodInSeconds;
   }
 
   @JsonIgnore
   public Instant getExpirationTimestamp() {
-    return getTimestamp().plusSeconds(durationInSeconds);
+    return getTimestamp().plusSeconds(validityPeriodInSeconds);
   }
 }

--- a/http/src/main/java/com/github/awsjavakit/http/updatestrategies/DefaultTokenCacheUpdateStrategy.java
+++ b/http/src/main/java/com/github/awsjavakit/http/updatestrategies/DefaultTokenCacheUpdateStrategy.java
@@ -1,0 +1,56 @@
+package com.github.awsjavakit.http.updatestrategies;
+
+import static java.util.Objects.isNull;
+
+import com.github.awsjavakit.http.token.OAuthTokenEntry;
+import java.util.Optional;
+import java.util.Random;
+import java.util.function.Supplier;
+
+public class DefaultTokenCacheUpdateStrategy implements TokenCacheUpdateStrategy<OAuthTokenEntry> {
+
+  public static final int MINIMUM_SLEEP_AMOUNT = 100;
+  public static final int MAX_SLEEP_AMOUNT = 400;
+  public static final Random RANDOM = new Random();
+  private final int minSleepPeriod;
+  private final int maxSleepPeriod;
+
+  public DefaultTokenCacheUpdateStrategy(int minSleepPeriod, int maxSleepPeriod) {
+    this.minSleepPeriod = minSleepPeriod;
+    this.maxSleepPeriod = maxSleepPeriod;
+  }
+
+  @Override
+  public OAuthTokenEntry fetchAndUpdate(
+    Supplier<OAuthTokenEntry> updateEntry,
+    Supplier<OAuthTokenEntry> fetchEntry) {
+    return fetchToken(fetchEntry)
+      .or(() -> someOtherProcessMightBeGeneratingAToken(fetchEntry))
+      .orElseGet(updateEntry);
+
+  }
+
+  private Optional<OAuthTokenEntry> fetchToken(Supplier<OAuthTokenEntry> tokenSupplier) {
+    var token = tokenSupplier.get();
+    return isNotValid(token) ? Optional.empty() : Optional.of(token);
+  }
+
+  private boolean isNotValid(OAuthTokenEntry token) {
+    return isNull(token) || token.hasExpired();
+  }
+
+  private Optional<OAuthTokenEntry> someOtherProcessMightBeGeneratingAToken(
+    Supplier<OAuthTokenEntry> tokenSupplier) {
+    sleep();
+    return fetchToken(tokenSupplier);
+  }
+
+  private void sleep() {
+    try {
+      Thread.sleep(minSleepPeriod + RANDOM.nextLong(maxSleepPeriod - minSleepPeriod));
+    } catch (InterruptedException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+}

--- a/http/src/main/java/com/github/awsjavakit/http/updatestrategies/DefaultTokenCacheUpdateStrategy.java
+++ b/http/src/main/java/com/github/awsjavakit/http/updatestrategies/DefaultTokenCacheUpdateStrategy.java
@@ -22,11 +22,11 @@ public class DefaultTokenCacheUpdateStrategy implements TokenCacheUpdateStrategy
 
   @Override
   public OAuthTokenEntry fetchAndUpdate(
-    Supplier<OAuthTokenEntry> updateEntry,
-    Supplier<OAuthTokenEntry> fetchEntry) {
-    return fetchToken(fetchEntry)
-      .or(() -> someOtherProcessMightBeGeneratingAToken(fetchEntry))
-      .orElseGet(updateEntry);
+    Supplier<OAuthTokenEntry> fetchCachedEntry,
+    Supplier<OAuthTokenEntry> updateCache) {
+    return fetchToken(fetchCachedEntry)
+      .or(() -> someOtherProcessMightBeGeneratingAToken(fetchCachedEntry))
+      .orElseGet(updateCache);
 
   }
 

--- a/http/src/main/java/com/github/awsjavakit/http/updatestrategies/TokenCacheUpdateStrategy.java
+++ b/http/src/main/java/com/github/awsjavakit/http/updatestrategies/TokenCacheUpdateStrategy.java
@@ -1,0 +1,8 @@
+package com.github.awsjavakit.http.updatestrategies;
+
+import java.util.function.Supplier;
+
+public interface TokenCacheUpdateStrategy<T> {
+
+  T fetchAndUpdate(Supplier<T> updateEntry, Supplier<T> fetchEntry);
+}

--- a/http/src/main/java/com/github/awsjavakit/http/updatestrategies/TokenCacheUpdateStrategy.java
+++ b/http/src/main/java/com/github/awsjavakit/http/updatestrategies/TokenCacheUpdateStrategy.java
@@ -1,8 +1,9 @@
 package com.github.awsjavakit.http.updatestrategies;
 
+import com.github.awsjavakit.http.token.OAuthTokenEntry;
 import java.util.function.Supplier;
 
 public interface TokenCacheUpdateStrategy<T> {
 
-  T fetchAndUpdate(Supplier<T> updateEntry, Supplier<T> fetchEntry);
+  T fetchAndUpdate(Supplier<OAuthTokenEntry> fetchCachedEntry, Supplier<T> updateCache);
 }


### PR DESCRIPTION
When having many lambdas to read and from the parameter store, and update the value, you run into the danger of many of them trying to update the access token simultaneously. Before, the strategy for avoiding this was hardcoded inside the `ParameterStoreCachedTokenProvider`.  This inflexibility causes several problems. 

Now the updating strategy has been extracted in a "strategy" class and we can be more flexible about how to update the token.