### PR TITLE
stop recursion when encountering a clock

### DIFF
--- a/buildSrc/src/main/groovy/com.github.awsjavakit.java-common-conventions.gradle
+++ b/buildSrc/src/main/groovy/com.github.awsjavakit.java-common-conventions.gradle
@@ -7,7 +7,7 @@ plugins {
 
 
 group 'io.github.awsjavakit'
-version = '0.11.0'
+version = '0.11.1'
 
 repositories {
     mavenCentral()

--- a/hamcrest/src/main/java/com/github/awsjavakit/hamcrest/hamcrest/DoesNotHaveEmptyValues.java
+++ b/hamcrest/src/main/java/com/github/awsjavakit/hamcrest/hamcrest/DoesNotHaveEmptyValues.java
@@ -5,6 +5,7 @@ import static java.util.Objects.isNull;
 import com.fasterxml.jackson.databind.JsonNode;
 import java.net.URI;
 import java.net.URL;
+import java.time.Clock;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -164,7 +165,8 @@ public class DoesNotHaveEmptyValues<T> extends BaseMatcher<T> {
   private Set<Class<?>> classesWithNoPojoStructure() {
     return Set.of(
       URI.class,
-      URL.class
+      URL.class,
+      Clock.class
     );
   }
 

--- a/hamcrest/src/test/java/com/github/awsjavakit/hamcrest/hamcrest/DoesNotHaveEmptyValuesTest.java
+++ b/hamcrest/src/test/java/com/github/awsjavakit/hamcrest/hamcrest/DoesNotHaveEmptyValuesTest.java
@@ -19,6 +19,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URL;
+import java.time.Clock;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -167,6 +168,13 @@ class DoesNotHaveEmptyValuesTest {
   }
 
   @Test
+  void shouldStopRecursionForClock() {
+    var entry = new ClassWithCustomObject<>(Clock.systemDefaultZone());
+    assertThat(entry, doesNotHaveEmptyValues());
+
+  }
+
+  @Test
   public void matchesDoesNotCheckFieldInAdditionalCustomIgnoreClass() {
     WithBaseTypes ignoredObjectWithEmptyProperties =
       new WithBaseTypes(null, null, null, null, null);
@@ -223,6 +231,8 @@ class DoesNotHaveEmptyValuesTest {
       doesNotHaveEmptyValuesIgnoringFieldsAndClasses(
         Set.of(WithBaseTypes.class), Set.of("someStringField")));
   }
+
+
 
   private static JsonNode nonEmptyJsonNode() {
     ObjectNode node = new ObjectMapper().createObjectNode();
@@ -398,6 +408,24 @@ class DoesNotHaveEmptyValuesTest {
     public String toString() {
       return "ClassWithList[" +
         "listWithIncompleteEntries=" + listWithIncompleteEntries + ']';
+    }
+
+  }
+
+  private static final class ClassWithCustomObject<T> {
+
+    private T customObject;
+
+    private ClassWithCustomObject(T customObject) {
+      this.customObject = customObject;
+    }
+
+    public T getCustomObject() {
+      return customObject;
+    }
+
+    public void setCustomObject(T customObject) {
+      this.customObject = customObject;
     }
 
   }

--- a/hamcrest/src/test/java/com/github/awsjavakit/hamcrest/hamcrest/DoesNotHaveEmptyValuesTest.java
+++ b/hamcrest/src/test/java/com/github/awsjavakit/hamcrest/hamcrest/DoesNotHaveEmptyValuesTest.java
@@ -26,7 +26,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
-import org.hamcrest.core.IsNot;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.function.Executable;

--- a/hamcrest/src/test/java/com/github/awsjavakit/hamcrest/hamcrest/DoesNotHaveEmptyValuesTest.java
+++ b/hamcrest/src/test/java/com/github/awsjavakit/hamcrest/hamcrest/DoesNotHaveEmptyValuesTest.java
@@ -10,6 +10,7 @@ import static com.github.awsjavakit.hamcrest.hamcrest.PropertyValuePair.RIGHT_BR
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.AllOf.allOf;
 import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsNot.not;
 import static org.hamcrest.core.StringContains.containsString;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -25,6 +26,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import org.hamcrest.core.IsNot;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.function.Executable;
@@ -171,7 +173,8 @@ class DoesNotHaveEmptyValuesTest {
   void shouldStopRecursionForClock() {
     var entry = new ClassWithCustomObject<>(Clock.systemDefaultZone());
     assertThat(entry, doesNotHaveEmptyValues());
-
+    var emptyEntry = new ClassWithCustomObject<Clock>(null);
+    assertThat(emptyEntry, not(doesNotHaveEmptyValues()));
   }
 
   @Test


### PR DESCRIPTION
The Clock class, does not have POJO structure and  when following the PropertyDescriptors to get the Clock's fields and the fields of the fields etc, one enters an infinite loop. With the PR we allow the library to check that the Clock field is not empty while avoiding entering an infinite loop.

This solution is not scalable, but I cannot think of any better solution at the moment. 