### PR TITLE
Integrate with resilience4j

### DIFF
--- a/buildSrc/src/main/groovy/com.github.awsjavakit.java-common-conventions.gradle
+++ b/buildSrc/src/main/groovy/com.github.awsjavakit.java-common-conventions.gradle
@@ -7,7 +7,7 @@ plugins {
 
 
 group 'io.github.awsjavakit'
-version = '0.15.1'
+version = '0.16.0'
 
 repositories {
     mavenCentral()

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -19,6 +19,7 @@ awsLambdaEvents = { strictly = '3.11.4' }
 awsLambdaCore = { strictly = '1.2.3' }
 lombok = { strictly = '1.18.30' }
 dynamoDbLocal = { strictly = '2.2.1' }
+resilience4j = {strictly= '2.2.0'}
 
 [libraries]
 log4j-core = { group = 'org.apache.logging.log4j', name = 'log4j-core', version.ref = 'log4j' }
@@ -66,6 +67,7 @@ mockito-junit = { group = 'org.mockito', name = 'mockito-junit-jupiter', version
 lombok = { group = 'org.projectlombok', name = 'lombok', version.ref = 'lombok' }
 dynamoDbLocal = { group = 'com.amazonaws', name = 'DynamoDBLocal', version.ref = 'dynamoDbLocal' }
 
+resilience4j = {group= 'io.github.resilience4j', name= 'resilience4j-retry', version.ref= 'resilience4j'}
 [bundles]
 testing = ["junit-api", "junit-engine", "junit-params", "assertj", "commons-lang", "datafaker", "hamcrest", "hamcrest-optional", "mockito-core", "mockito-junit", "dynamoDbLocal", 'hamcrest-jackson']
 json = ['jackson-core', 'jackson-datatype-jdk8', 'jackson-databind', 'jackson-annotations', "jackson-datatype-jsr310"]

--- a/http/build.gradle
+++ b/http/build.gradle
@@ -18,7 +18,7 @@ dependencies {
     implementation project(":attempt")
     implementation project(":misc")
 
-    testImplementation group: 'io.github.resilience4j', name: 'resilience4j-retry', version: '2.2.0'
+
     testImplementation project(":testingutils")
     testImplementation project(":secrets")
     testImplementation libs.aws.ssm
@@ -27,6 +27,7 @@ dependencies {
     testImplementation libs.wiremock
     testImplementation libs.aws.secrets
     testImplementation libs.aws.s3
+    testImplementation libs.resilience4j
 
 
 

--- a/http/build.gradle
+++ b/http/build.gradle
@@ -18,7 +18,7 @@ dependencies {
     implementation project(":attempt")
     implementation project(":misc")
 
-
+    testImplementation group: 'io.github.resilience4j', name: 'resilience4j-retry', version: '2.2.0'
     testImplementation project(":testingutils")
     testImplementation project(":secrets")
     testImplementation libs.aws.ssm

--- a/http/src/main/java/com/github/awsjavakit/http/RetryStrategy.java
+++ b/http/src/main/java/com/github/awsjavakit/http/RetryStrategy.java
@@ -3,33 +3,44 @@ package com.github.awsjavakit.http;
 import static com.gtihub.awsjavakit.attempt.Try.attempt;
 
 import com.gtihub.awsjavakit.attempt.FunctionWithException;
+import java.time.Duration;
 
 @FunctionalInterface
 public interface RetryStrategy {
 
-  <I, O, E extends Exception> O apply(FunctionWithException<I, O, E> trial, I input);
+  static RetryStrategy defaultStrategy(Duration waitingTime) {
+    return new DefaultRetryStrategy(waitingTime);
+  }
+
+  //We cannot avoid throwing the generic Exception because external libraries
+  // (e.g. resilience4j) throw it, and we need to integrate with them
+  @SuppressWarnings("PMD.SignatureDeclareThrowsException")
+  <I, O, E extends Exception> O apply(FunctionWithException<I, O, E> trial, I input)
+    throws Exception;
 
   class DefaultRetryStrategy implements RetryStrategy {
 
-    private final int waitingTime;
+    private final Duration waitingTime;
 
-    public DefaultRetryStrategy(int waitingTime) {
+    public DefaultRetryStrategy(Duration waitingTime) {
       this.waitingTime = waitingTime;
     }
 
     @Override
-    public <I, O, E extends Exception> O apply(FunctionWithException<I, O, E> function, I input) {
-      return attempt(() -> function.apply(input)).orElse(fail->retry(function,input));
+    public <I, O, E extends Exception> O apply(FunctionWithException<I, O, E> function, I input)
+      throws E {
+      return attempt(() -> function.apply(input)).orElse(fail -> retry(function, input));
     }
 
-    private <I, O, E extends Exception> O retry(FunctionWithException<I, O, E> function, I input) {
+    private <I, O, E extends Exception> O retry(FunctionWithException<I, O, E> function, I input)
+      throws E {
       pause();
-      return attempt(() -> function.apply(input)).orElseThrow();
+      return function.apply(input);
     }
 
     private void pause() {
       try {
-        Thread.sleep(waitingTime);
+        Thread.sleep(waitingTime.toMillis());
       } catch (InterruptedException e) {
         throw new RuntimeException(e);
       }

--- a/http/src/main/java/com/github/awsjavakit/http/RetryingHttpClient.java
+++ b/http/src/main/java/com/github/awsjavakit/http/RetryingHttpClient.java
@@ -88,7 +88,7 @@ public final class RetryingHttpClient extends HttpClient {
 
   @Override
   public <T> HttpResponse<T> send(HttpRequest request, BodyHandler<T> responseBodyHandler) {
-    return retryStrategy.apply(() -> httpClient.send(request, responseBodyHandler));
+    return retryStrategy.apply(req -> httpClient.send(req, responseBodyHandler),request);
   }
 
   @Override

--- a/http/src/main/java/com/github/awsjavakit/http/RetryingHttpClient.java
+++ b/http/src/main/java/com/github/awsjavakit/http/RetryingHttpClient.java
@@ -1,6 +1,7 @@
 package com.github.awsjavakit.http;
 
 import com.github.awsjavakit.misc.JacocoGenerated;
+import java.io.IOException;
 import java.net.Authenticator;
 import java.net.CookieHandler;
 import java.net.ProxySelector;
@@ -85,10 +86,19 @@ public final class RetryingHttpClient extends HttpClient {
     return httpClient.executor();
   }
 
-
+  //We need to suppress the warning because we want the original IOExceptions and InterruptedExceptions
+  // to be thrown as they are and not to be wrapped to runtime exceptions as this would change the contract.
   @Override
-  public <T> HttpResponse<T> send(HttpRequest request, BodyHandler<T> responseBodyHandler) {
-    return retryStrategy.apply(req -> httpClient.send(req, responseBodyHandler),request);
+  @SuppressWarnings("PMD.AvoidRethrowingException")
+  public <T> HttpResponse<T> send(HttpRequest request, BodyHandler<T> responseBodyHandler)
+    throws IOException, InterruptedException {
+    try {
+      return retryStrategy.apply(req -> httpClient.send(req, responseBodyHandler), request);
+    } catch (IOException | InterruptedException | RuntimeException httpClientException) {
+      throw httpClientException;
+    } catch (Exception nonHttpClientException) {
+      throw new RuntimeException(nonHttpClientException);
+    }
   }
 
   @Override

--- a/http/src/test/java/com/github/awsjavakit/http/ResilienceRetryStrategy.java
+++ b/http/src/test/java/com/github/awsjavakit/http/ResilienceRetryStrategy.java
@@ -1,7 +1,6 @@
 package com.github.awsjavakit.http;
 
 import com.gtihub.awsjavakit.attempt.FunctionWithException;
-import io.github.resilience4j.core.functions.CheckedSupplier;
 import io.github.resilience4j.retry.RetryConfig;
 import io.github.resilience4j.retry.RetryRegistry;
 import java.time.Duration;
@@ -20,18 +19,8 @@ public class ResilienceRetryStrategy implements RetryStrategy {
   }
 
   @Override
-  public <I, O, E extends Exception> O apply(FunctionWithException<I, O, E> trial, I input) {
-    var checkedSupplier = new CheckedSupplier<O>() {
-      @Override
-      public O get() throws Throwable {
-        return trial.apply(input);
-      }
-    };
-    try {
-      return registry.retry(input.toString()).executeCheckedSupplier(checkedSupplier);
-    } catch (Throwable e) {
-      throw new RuntimeException(e);
-    }
-
+  public <I, O, E extends Exception> O apply(FunctionWithException<I, O, E> trial, I input)
+    throws Exception {
+    return registry.retry(input.toString()).executeCallable(() -> trial.apply(input));
   }
 }

--- a/http/src/test/java/com/github/awsjavakit/http/ResilienceRetryStrategy.java
+++ b/http/src/test/java/com/github/awsjavakit/http/ResilienceRetryStrategy.java
@@ -1,0 +1,37 @@
+package com.github.awsjavakit.http;
+
+import com.gtihub.awsjavakit.attempt.FunctionWithException;
+import io.github.resilience4j.core.functions.CheckedSupplier;
+import io.github.resilience4j.retry.RetryConfig;
+import io.github.resilience4j.retry.RetryRegistry;
+import java.time.Duration;
+
+public class ResilienceRetryStrategy implements RetryStrategy {
+
+  private final RetryRegistry registry;
+
+  public ResilienceRetryStrategy() {
+    var config = RetryConfig.custom()
+      .maxAttempts(2)
+      .waitDuration(Duration.ofMillis(1))
+      .build();
+    this.registry = RetryRegistry.of(config);
+
+  }
+
+  @Override
+  public <I, O, E extends Exception> O apply(FunctionWithException<I, O, E> trial, I input) {
+    var checkedSupplier = new CheckedSupplier<O>() {
+      @Override
+      public O get() throws Throwable {
+        return trial.apply(input);
+      }
+    };
+    try {
+      return registry.retry(input.toString()).executeCheckedSupplier(checkedSupplier);
+    } catch (Throwable e) {
+      throw new RuntimeException(e);
+    }
+
+  }
+}

--- a/http/src/test/java/com/github/awsjavakit/http/RetryingHttpClientTest.java
+++ b/http/src/test/java/com/github/awsjavakit/http/RetryingHttpClientTest.java
@@ -122,7 +122,7 @@ class RetryingHttpClientTest {
 
   @ParameterizedTest
   @MethodSource("failingHttpClient")
-  void shouldRethrowTheCheckedExceptionsContainedHttpClientHasThrown(ExceptionTestSetup testSetup) {
+  void shouldRethrowTheCheckedExceptionsTheContainedHttpClientHasThrown(ExceptionTestSetup testSetup) {
     var failingClient = testSetup.failingClient();
     var retryClient =
       RetryingHttpClient.create(failingClient,RetryStrategy.defaultStrategy(Duration.ZERO));

--- a/http/src/test/java/com/github/awsjavakit/http/RetryingHttpClientTest.java
+++ b/http/src/test/java/com/github/awsjavakit/http/RetryingHttpClientTest.java
@@ -122,10 +122,11 @@ class RetryingHttpClientTest {
 
   @ParameterizedTest
   @MethodSource("failingHttpClient")
-  void shouldRethrowTheCheckedExceptionsTheContainedHttpClientHasThrown(ExceptionTestSetup testSetup) {
+  void shouldRethrowTheCheckedExceptionsTheContainedHttpClientHasThrown(
+    ExceptionTestSetup testSetup) {
     var failingClient = testSetup.failingClient();
     var retryClient =
-      RetryingHttpClient.create(failingClient,RetryStrategy.defaultStrategy(Duration.ZERO));
+      RetryingHttpClient.create(failingClient, RetryStrategy.defaultStrategy(Duration.ZERO));
     Executable action = () -> retryClient.send(dummyRequest(), BodyHandlers.ofString());
     var exception = assertThrows(testSetup.exception().getClass(), action);
     assertThat(exception.getMessage()).isEqualTo(testSetup.exception().getMessage());
@@ -158,13 +159,13 @@ class RetryingHttpClientTest {
 
   private void setupServerToFirstFailThenSucceed() {
     this.server.stubFor(get(RANDOMLY_FAILING_ENDPOINT)
-      .inScenario("FirstRequest")
+      .inScenario("FirstFailThenSucceed")
       .whenScenarioStateIs(STARTED)
       .willReturn(aResponse().withFault(Fault.RANDOM_DATA_THEN_CLOSE))
       .willSetStateTo("Failed"));
 
     this.server.stubFor(get(RANDOMLY_FAILING_ENDPOINT)
-      .inScenario("FirstRequest")
+      .inScenario("FirstFailThenSucceed")
       .whenScenarioStateIs("Failed")
       .willReturn(aResponse().withBody(expectedResponseBody))
       .willSetStateTo(STARTED));

--- a/http/src/test/java/com/github/awsjavakit/http/RetryingHttpClientTest.java
+++ b/http/src/test/java/com/github/awsjavakit/http/RetryingHttpClientTest.java
@@ -1,38 +1,57 @@
 package com.github.awsjavakit.http;
 
 import static com.github.awsjavakit.testingutils.RandomDataGenerator.randomString;
+import static com.github.awsjavakit.testingutils.RandomDataGenerator.randomUri;
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.anyUrl;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
 import static com.github.tomakehurst.wiremock.stubbing.Scenario.STARTED;
+import static com.gtihub.awsjavakit.attempt.Try.attempt;
 import static java.net.HttpURLConnection.HTTP_OK;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import com.github.awsjavakit.http.RetryStrategy.DefaultRetryStrategy;
 import com.github.awsjavakit.misc.paths.UriWrapper;
 import com.github.awsjavakit.testingutils.networking.WiremockHttpClient;
 import com.github.tomakehurst.wiremock.WireMockServer;
 import com.github.tomakehurst.wiremock.http.Fault;
+import java.io.IOException;
 import java.net.URI;
+import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
+import java.net.http.HttpResponse.BodyHandler;
 import java.net.http.HttpResponse.BodyHandlers;
 import java.nio.charset.StandardCharsets;
+import java.time.Duration;
 import java.util.concurrent.ExecutionException;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Named;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.function.Executable;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 class RetryingHttpClientTest {
 
   public static final String RANDOMLY_FAILING_ENDPOINT = "/first-fail/then-succeed";
-  public static final String ANOTHER_RANDOMLY_FAILING_ENDPOINT = "/some-other-fail/then-succeed";
 
   private WireMockServer server;
   private URI serverUri;
   private String expectedResponseBody;
+
+  public static Stream<Named<ExceptionTestSetup>> failingHttpClient() {
+    return Stream.of(new IOException(randomString()), new InterruptedException(randomString()))
+      .map(ExceptionTestSetup::new)
+      .map(setup -> Named.of(setup.name(), setup));
+
+  }
 
   @BeforeEach
   public void init() {
@@ -44,11 +63,11 @@ class RetryingHttpClientTest {
   }
 
   @Test
-  void shouldRetrySyncRequestsBasedOnTheRetryPolicy() {
+  void shouldRetrySyncRequestsBasedOnTheRetryPolicy() throws IOException, InterruptedException {
     setupServerToFirstFailThenSucceed();
 
     var client = RetryingHttpClient.create(WiremockHttpClient.create().build(),
-      new DefaultRetryStrategy(1));
+      new DefaultRetryStrategy(Duration.ZERO));
     var requestUri = UriWrapper.fromUri(serverUri)
       .addChild(RANDOMLY_FAILING_ENDPOINT).getUri();
     var request = HttpRequest.newBuilder(requestUri).GET().build();
@@ -58,11 +77,11 @@ class RetryingHttpClientTest {
   }
 
   @Test
-  void shouldNotRepeatRequestIfThereIsNoError() {
+  void shouldNotRepeatRequestIfThereIsNoError() throws IOException, InterruptedException {
     setupServerToAlwaysSucceed();
 
     var client = RetryingHttpClient.create(WiremockHttpClient.create().build(),
-      new DefaultRetryStrategy(1));
+      new DefaultRetryStrategy(Duration.ZERO));
     var requestUri = UriWrapper.fromUri(serverUri)
       .addChild(RANDOMLY_FAILING_ENDPOINT).getUri();
     var request = HttpRequest.newBuilder(requestUri).GET().build();
@@ -76,11 +95,11 @@ class RetryingHttpClientTest {
   void shouldFailEventually() {
     setupServerToAlwaysFail();
     var client = RetryingHttpClient.create(WiremockHttpClient.create().build(),
-      new DefaultRetryStrategy(1));
+      new DefaultRetryStrategy(Duration.ZERO));
     var requestUri = UriWrapper.fromUri(serverUri)
       .addChild(RANDOMLY_FAILING_ENDPOINT).getUri();
     var request = HttpRequest.newBuilder(requestUri).GET().build();
-    assertThrows(RuntimeException.class,
+    assertThrows(IOException.class,
       () -> client.send(request, BodyHandlers.ofString(StandardCharsets.UTF_8)));
 
   }
@@ -90,7 +109,7 @@ class RetryingHttpClientTest {
     setupServerToFirstFailThenSucceed();
     var client = RetryingHttpClient.create(
       WiremockHttpClient.create().build(),
-      new DefaultRetryStrategy(1));
+      new DefaultRetryStrategy(Duration.ZERO));
     var requestUri = UriWrapper.fromUri(serverUri)
       .addChild(RANDOMLY_FAILING_ENDPOINT).getUri();
     var request = HttpRequest.newBuilder(requestUri).GET().build();
@@ -101,11 +120,23 @@ class RetryingHttpClientTest {
     assertThrows(ExecutionException.class, action);
   }
 
+  @ParameterizedTest
+  @MethodSource("failingHttpClient")
+  void shouldRethrowTheCheckedExceptionsContainedHttpClientHasThrown(ExceptionTestSetup testSetup) {
+    var failingClient = testSetup.failingClient();
+    var retryClient =
+      RetryingHttpClient.create(failingClient,RetryStrategy.defaultStrategy(Duration.ZERO));
+    Executable action = () -> retryClient.send(dummyRequest(), BodyHandlers.ofString());
+    var exception = assertThrows(testSetup.exception().getClass(), action);
+    assertThat(exception.getMessage()).isEqualTo(testSetup.exception().getMessage());
+
+  }
+
   @Test
-  void shouldIntegrateWithExternalResilienceLibraries() {
+  void shouldIntegrateWithExternalResilienceLibraries() throws IOException, InterruptedException {
     setupServerToFirstFailThenSucceed();
 
-    var retryStrategy = new ResilienceRetryStrategy() ;
+    var retryStrategy = new ResilienceRetryStrategy();
     var client = RetryingHttpClient.create(WiremockHttpClient.create().build(), retryStrategy);
     var requestUri = UriWrapper.fromUri(serverUri)
       .addChild(RANDOMLY_FAILING_ENDPOINT).getUri();
@@ -114,6 +145,10 @@ class RetryingHttpClientTest {
     assertThat(response.statusCode()).isEqualTo(HTTP_OK);
     assertThat(response.body()).isEqualTo(expectedResponseBody);
     server.verify(2, getRequestedFor(anyUrl()));
+  }
+
+  private HttpRequest dummyRequest() {
+    return HttpRequest.newBuilder(randomUri()).GET().build();
   }
 
   private void setupServerToAlwaysSucceed() {
@@ -142,4 +177,18 @@ class RetryingHttpClientTest {
 
   }
 
+  public record ExceptionTestSetup(Exception exception) {
+
+    public String name() {
+      return exception.getClass().getSimpleName();
+    }
+
+    public HttpClient failingClient() {
+      var client = mock(HttpClient.class);
+      attempt(() -> when(client.send(any(HttpRequest.class), any(BodyHandler.class)))
+        .thenThrow(exception)).orElseThrow();
+      return client;
+
+    }
+  }
 }

--- a/http/src/test/java/com/github/awsjavakit/http/RetryingHttpClientTest.java
+++ b/http/src/test/java/com/github/awsjavakit/http/RetryingHttpClientTest.java
@@ -8,7 +8,6 @@ import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
 import static com.github.tomakehurst.wiremock.stubbing.Scenario.STARTED;
-import static com.gtihub.awsjavakit.attempt.Try.attempt;
 import static java.net.HttpURLConnection.HTTP_OK;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -123,7 +122,7 @@ class RetryingHttpClientTest {
   @ParameterizedTest
   @MethodSource("failingHttpClient")
   void shouldRethrowTheCheckedExceptionsTheContainedHttpClientHasThrown(
-    ExceptionTestSetup testSetup) {
+    ExceptionTestSetup testSetup) throws IOException, InterruptedException {
     var failingClient = testSetup.failingClient();
     var retryClient =
       RetryingHttpClient.create(failingClient, RetryStrategy.defaultStrategy(Duration.ZERO));
@@ -184,10 +183,9 @@ class RetryingHttpClientTest {
       return exception.getClass().getSimpleName();
     }
 
-    public HttpClient failingClient() {
+    public HttpClient failingClient() throws IOException, InterruptedException {
       var client = mock(HttpClient.class);
-      attempt(() -> when(client.send(any(HttpRequest.class), any(BodyHandler.class)))
-        .thenThrow(exception)).orElseThrow();
+      when(client.send(any(HttpRequest.class), any(BodyHandler.class))).thenThrow(exception);
       return client;
 
     }


### PR DESCRIPTION
This PR enables RetryingHttpClient to make use of the resilience4j library (and other ones)