### PR TITLE
instant close to

### DIFF
--- a/buildSrc/src/main/groovy/com.github.awsjavakit.java-common-conventions.gradle
+++ b/buildSrc/src/main/groovy/com.github.awsjavakit.java-common-conventions.gradle
@@ -7,7 +7,7 @@ plugins {
 
 
 group 'io.github.awsjavakit'
-version = '0.18.2'
+version = '0.18.3'
 
 repositories {
     mavenCentral()

--- a/testingutils/src/main/java/com/github/awsjavakit/testingutils/hamcrest/InstantIsCloseTo.java
+++ b/testingutils/src/main/java/com/github/awsjavakit/testingutils/hamcrest/InstantIsCloseTo.java
@@ -1,0 +1,36 @@
+package com.github.awsjavakit.testingutils.hamcrest;
+
+import java.time.Duration;
+import java.time.Instant;
+import org.hamcrest.BaseMatcher;
+import org.hamcrest.Description;
+
+public class InstantIsCloseTo extends BaseMatcher<Instant> {
+
+  private final Instant expected;
+  private final Duration error;
+
+  public InstantIsCloseTo(Instant expected, Duration duration) {
+    super();
+    this.expected = expected;
+    this.error = duration;
+  }
+
+  public static InstantIsCloseTo closeTo(Instant expected, Duration duration) {
+    return new InstantIsCloseTo(expected, duration);
+  }
+
+  @Override
+  public boolean matches(Object o) {
+    var actual = (Instant) o;
+    var minExpected = expected.minus(error);
+    var maxExpected = expected.plus(error);
+
+    return !actual.isBefore(minExpected) && !actual.isAfter(maxExpected);
+  }
+
+  @Override
+  public void describeTo(Description description) {
+    description.appendText(expected.toString());
+  }
+}

--- a/testingutils/src/test/java/com/github/awsjavakit/testingutils/hamcrest/InstantIsCloseToTest.java
+++ b/testingutils/src/test/java/com/github/awsjavakit/testingutils/hamcrest/InstantIsCloseToTest.java
@@ -1,0 +1,45 @@
+package com.github.awsjavakit.testingutils.hamcrest;
+
+import static com.github.awsjavakit.testingutils.hamcrest.InstantIsCloseTo.closeTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.core.Is.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import java.time.Duration;
+import java.time.Instant;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.Executable;
+
+class InstantIsCloseToTest {
+
+  @Test
+  void shouldReturnTrueIfActualIsEqualToExpected() {
+    var expected = Instant.parse("1980-01-01T00:00:00z");
+    var actual = Instant.parse("1980-01-01T00:00:00z");
+    assertThat(actual, is(closeTo(expected, Duration.ofSeconds(1))));
+  }
+
+  @Test
+  void shouldReturnFalseIfActualIsNotEqualToExpected() {
+    var expected = Instant.parse("1980-01-01T00:00:00z");
+    var actual = Instant.now();
+    Executable action = () -> assertThat(actual, is(closeTo(expected, Duration.ofSeconds(1))));
+    var error= assertThrows(AssertionError.class, action);
+    assertThat(error.getMessage(),containsString(expected.toString()));
+  }
+
+  @Test
+  void shouldReturnTrueIfActualIsWithinAcceptableRange() {
+    var expected = Instant.parse("1980-01-01T00:00:00z");
+    var actual = Instant.parse("1980-01-01T00:00:05z");
+    assertThat(actual, is(closeTo(expected, Duration.ofSeconds(10))));
+  }
+
+  @Test
+  void shouldAcceptZeroDuration(){
+    var expected = Instant.parse("1980-01-01T00:00:00z");
+    var actual = Instant.parse("1980-01-01T00:00:00z");
+    assertThat(actual, is(closeTo(expected, Duration.ZERO)));
+  }
+
+}

--- a/testingutils/src/test/java/com/github/awsjavakit/testingutils/hamcrest/InstantIsCloseToTest.java
+++ b/testingutils/src/test/java/com/github/awsjavakit/testingutils/hamcrest/InstantIsCloseToTest.java
@@ -13,14 +13,14 @@ import org.junit.jupiter.api.function.Executable;
 class InstantIsCloseToTest {
 
   @Test
-  void shouldReturnTrueIfActualIsEqualToExpected() {
+  void shouldSucceedWhenActualIsEqualToExpected() {
     var expected = Instant.parse("1980-01-01T00:00:00z");
     var actual = Instant.parse("1980-01-01T00:00:00z");
     assertThat(actual, is(closeTo(expected, Duration.ofSeconds(1))));
   }
 
   @Test
-  void shouldReturnFalseIfActualIsNotEqualToExpected() {
+  void shouldFailWhenActualIsNotEqualToExpected() {
     var expected = Instant.parse("1980-01-01T00:00:00z");
     var actual = Instant.now();
     Executable action = () -> assertThat(actual, is(closeTo(expected, Duration.ofSeconds(1))));
@@ -29,7 +29,7 @@ class InstantIsCloseToTest {
   }
 
   @Test
-  void shouldReturnTrueIfActualIsWithinAcceptableRange() {
+  void shouldSucceedIfActualIsWithinAcceptableRange() {
     var expected = Instant.parse("1980-01-01T00:00:00z");
     var actual = Instant.parse("1980-01-01T00:00:05z");
     assertThat(actual, is(closeTo(expected, Duration.ofSeconds(10))));


### PR DESCRIPTION
an equality comparator of instants with some error tolerance.  Named following the hamcrest pattern of the method `org.hamcrest.numberIsCloseTo::closeTo`