### PR TITLE
doesNotHaveEmtyValues does not fail on non empty string json nodes

### DIFF
--- a/buildSrc/src/main/groovy/com.github.awsjavakit.java-common-conventions.gradle
+++ b/buildSrc/src/main/groovy/com.github.awsjavakit.java-common-conventions.gradle
@@ -8,7 +8,7 @@ plugins {
 
 
 group 'io.github.awsjavakit'
-version = '0.19.0'
+version = '0.19.1'
 
 repositories {
     mavenCentral()

--- a/hamcrest/src/main/java/com/github/awsjavakit/hamcrest/hamcrest/DoesNotHaveEmptyValues.java
+++ b/hamcrest/src/main/java/com/github/awsjavakit/hamcrest/hamcrest/DoesNotHaveEmptyValues.java
@@ -127,8 +127,8 @@ public class DoesNotHaveEmptyValues<T> extends BaseMatcher<T> {
     }
   }
 
-  private static boolean isEmptyContainer(JsonNode n) {
-    return n.isContainerNode() && n.isEmpty();
+  private static boolean isEmptyContainer(JsonNode node) {
+    return node.isContainerNode() && node.isEmpty();
   }
 
   private List<PropertyValuePair> createListWithFieldsToBeChecked(PropertyValuePair rootObject) {

--- a/hamcrest/src/main/java/com/github/awsjavakit/hamcrest/hamcrest/DoesNotHaveEmptyValues.java
+++ b/hamcrest/src/main/java/com/github/awsjavakit/hamcrest/hamcrest/DoesNotHaveEmptyValues.java
@@ -127,6 +127,10 @@ public class DoesNotHaveEmptyValues<T> extends BaseMatcher<T> {
     }
   }
 
+  private static boolean isEmptyContainer(JsonNode n) {
+    return n.isContainerNode() && n.isEmpty();
+  }
+
   private List<PropertyValuePair> createListWithFieldsToBeChecked(PropertyValuePair rootObject) {
     List<PropertyValuePair> fieldsToBeChecked = new ArrayList<>();
     Stack<PropertyValuePair> fieldsToBeVisited = initializeFieldsToBeVisited(rootObject);
@@ -147,7 +151,7 @@ public class DoesNotHaveEmptyValues<T> extends BaseMatcher<T> {
   }
 
   private void addNestedFieldsToFieldsToBeVisited(Stack<PropertyValuePair> fieldsToBeVisited,
-    PropertyValuePair currentField) {
+                                                  PropertyValuePair currentField) {
     if (currentField.isComplexObject()) {
       fieldsToBeVisited.addAll(currentField.children());
     } else if (currentField.isCollection()) {
@@ -156,7 +160,7 @@ public class DoesNotHaveEmptyValues<T> extends BaseMatcher<T> {
   }
 
   private void addEachArrayElementAsFieldToBeVisited(Stack<PropertyValuePair> fieldsToBeVisited,
-    PropertyValuePair currentField) {
+                                                     PropertyValuePair currentField) {
     List<PropertyValuePair> collectionElements = currentField.createPropertyValuePairsForEachCollectionItem();
     fieldsToBeVisited.addAll(collectionElements);
   }
@@ -196,9 +200,17 @@ public class DoesNotHaveEmptyValues<T> extends BaseMatcher<T> {
 
   private boolean isEmptyJsonNode(Object value) {
     if (value instanceof JsonNode) {
-      return ((JsonNode) value).isEmpty();
+      return isEmptyContainer((JsonNode) value) || isEmptyValueNode((JsonNode) value);
     }
     return false;
+  }
+
+  private boolean isEmptyValueNode(JsonNode value) {
+    if (value.isTextual()) {
+      return isNull(value.textValue()) || value.textValue().isBlank();
+    }
+    return value.isMissingNode() || value.isNull();
+
   }
 
   private boolean isEmptyCollection(Object value) {

--- a/hamcrest/src/test/java/com/github/awsjavakit/hamcrest/hamcrest/DoesNotHaveEmptyValuesTest.java
+++ b/hamcrest/src/test/java/com/github/awsjavakit/hamcrest/hamcrest/DoesNotHaveEmptyValuesTest.java
@@ -13,6 +13,7 @@ import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsNot.not;
 import static org.hamcrest.core.StringContains.containsString;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.net.MalformedURLException;
@@ -234,7 +235,8 @@ class DoesNotHaveEmptyValuesTest {
 
   @Test
   void shouldAcceptRecordWithNoEmptyFields() {
-    var customObject = new ClassWithCustomObject<>(new ClassWithUri<>(EXAMPLE_URI, "someOtherField"));
+    var customObject = new ClassWithCustomObject<>(
+      new ClassWithUri<>(EXAMPLE_URI, "someOtherField"));
     var record = new RecordWithFields<>("someStringField1", "someStringField2", customObject);
     assertThat(record, doesNotHaveEmptyValues());
   }
@@ -259,10 +261,34 @@ class DoesNotHaveEmptyValuesTest {
     assertThat(error.getMessage(), containsString("stringField"));
   }
 
+  @Test
+  void shouldFailWhenClassCopntainsRecordWithEmptyFields() {
+    var object = new ClassWithCustomObject<>(
+      new RecordWithFields<String>(null, "someString", "someString"));
+    var exception =
+      assertThrows(AssertionError.class, () -> assertThat(object, doesNotHaveEmptyValues()));
+    assertThat(exception.getMessage(), containsString("field1"));
+  }
+
+  @Test
+  void shouldSucceedWhenInputContainsANonEmptyTextNode() throws JsonProcessingException {
+    var sampleObject = new WithBaseTypes(STRING_FIELD,
+      1,
+      List.of("someString"),
+      Map.of("someString", "someString"),
+      randomTextNode());
+    assertThat(sampleObject, doesNotHaveEmptyValues());
+  }
+
   private static JsonNode nonEmptyJsonNode() {
     var node = new ObjectMapper().createObjectNode();
     node.put(SAMPLE_STRING, SAMPLE_STRING);
     return node;
+  }
+
+  private JsonNode randomTextNode() throws JsonProcessingException {
+    var someStringValue = String.format("\"%s\"", "someString");
+    return JSON.readTree(someStringValue);
   }
 
   private void assertThatContainedObjectHasEmptyFields(WithBaseTypes withBaseTypes) {

--- a/hamcrest/src/test/java/com/github/awsjavakit/hamcrest/hamcrest/DoesNotHaveEmptyValuesTest.java
+++ b/hamcrest/src/test/java/com/github/awsjavakit/hamcrest/hamcrest/DoesNotHaveEmptyValuesTest.java
@@ -262,7 +262,7 @@ class DoesNotHaveEmptyValuesTest {
   }
 
   @Test
-  void shouldFailWhenClassCopntainsRecordWithEmptyFields() {
+  void shouldFailWhenClassContainsRecordWithEmptyFields() {
     var object = new ClassWithCustomObject<>(
       new RecordWithFields<String>(null, "someString", "someString"));
     var exception =


### PR DESCRIPTION
doesNotHaveEmptyValues() was considering a JsonNode with a text value to be an empty node due to the JsonNode::isEmpty default implementation returning true. In other words the Jackson method  TextNode::isEmpty returns true and that messes up the check