### PR TITLE
Virtual Future

### DIFF
--- a/misc/src/main/java/com/github/awsjavakit/misc/virtualfuture/VirtualFuture.java
+++ b/misc/src/main/java/com/github/awsjavakit/misc/virtualfuture/VirtualFuture.java
@@ -1,6 +1,5 @@
 package com.github.awsjavakit.misc.virtualfuture;
 
-import com.gtihub.awsjavakit.attempt.FunctionWithException;
 import java.util.Arrays;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
@@ -8,21 +7,20 @@ import java.util.function.Supplier;
 
 public final class VirtualFuture<A> {
 
+
   private final Supplier<A> task;
   private final CompletableFuture<A> future;
 
   private VirtualFuture(Supplier<A> task) {
     this.task = task;
     this.future = new CompletableFuture<>();
-    Thread.startVirtualThread(() -> {
-      executeTaskInsideCompletableFuture(future);
-    });
+    Thread.startVirtualThread(() -> executeTaskInsideCompletableFuture(future));
 
   }
 
   public VirtualFuture(CompletableFuture<A> future) {
     this.future = future;
-    this.task = () -> null;
+    this.task = null;
   }
 
   public static <A> VirtualFuture<A> supply(Supplier<A> task) {

--- a/misc/src/main/java/com/github/awsjavakit/misc/virtualfuture/VirtualFuture.java
+++ b/misc/src/main/java/com/github/awsjavakit/misc/virtualfuture/VirtualFuture.java
@@ -1,0 +1,41 @@
+package com.github.awsjavakit.misc.virtualfuture;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.function.Supplier;
+
+public final class VirtualFuture<A> {
+
+  private final Supplier<A> task;
+  private final CompletableFuture<A> future;
+
+  private VirtualFuture(Supplier<A> task) {
+    this.task = task;
+    this.future = new CompletableFuture<>();
+    Thread.startVirtualThread(() -> {
+      executeTaskInsideCompletableFuture(future);
+    });
+
+  }
+
+  public static <A> VirtualFuture<A> supply(Supplier<A> task) {
+    return new VirtualFuture<>(task);
+  }
+
+  public A join() {
+    return this.future.join();
+  }
+
+  public A get() throws ExecutionException, InterruptedException {
+    return future.get();
+  }
+
+
+  private void executeTaskInsideCompletableFuture(CompletableFuture<A> future) {
+    try {
+      future.complete(task.get());
+    } catch (Exception e) {
+      future.completeExceptionally(e);
+    }
+  }
+}

--- a/misc/src/test/java/com/github/awsjavakit/misc/virtualfuture/VirtualFutureTest.java
+++ b/misc/src/test/java/com/github/awsjavakit/misc/virtualfuture/VirtualFutureTest.java
@@ -1,0 +1,25 @@
+package com.github.awsjavakit.misc.virtualfuture;
+
+import static com.github.awsjavakit.testingutils.RandomDataGenerator.randomInteger;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+import java.util.concurrent.ExecutionException;
+import org.junit.jupiter.api.Test;
+
+class VirtualFutureTest {
+
+  private static final Integer TASK_RESULT = randomInteger();
+
+  @Test
+  void shouldExecuteSuppliedTask() throws ExecutionException, InterruptedException {
+    var future = VirtualFuture.supply(this::task);
+    future.join();
+    var result = future.get();
+    assertThat(result).isEqualTo(TASK_RESULT);
+  }
+
+  private Integer task() {
+    return TASK_RESULT;
+  }
+
+}

--- a/misc/src/test/java/com/github/awsjavakit/misc/virtualfuture/VirtualFutureTest.java
+++ b/misc/src/test/java/com/github/awsjavakit/misc/virtualfuture/VirtualFutureTest.java
@@ -1,14 +1,21 @@
 package com.github.awsjavakit.misc.virtualfuture;
 
 import static com.github.awsjavakit.testingutils.RandomDataGenerator.randomInteger;
+import static com.gtihub.awsjavakit.attempt.Try.attempt;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
+import com.gtihub.awsjavakit.attempt.Try;
+import java.time.Duration;
+import java.time.Instant;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
+import java.util.stream.IntStream;
+import org.apache.commons.lang3.IntegerRange;
 import org.junit.jupiter.api.Test;
 
 class VirtualFutureTest {
 
+  public static final int MUCH_LESS_TIME_THAN_SUM_OF_DELAYS = 5;
   private static final Integer TASK_RESULT = randomInteger();
 
   @Test
@@ -34,8 +41,65 @@ class VirtualFutureTest {
     }
   }
 
+  @Test
+  void shouldExecuteTasksInParallel() {
+    var range = IntegerRange.of(0, 100);
+    var startTime = Instant.now();
+
+    var futures = IntStream.range(range.getMinimum(), range.getMaximum() + 1)
+      .boxed()
+      .map(number -> VirtualFuture.supply(() -> taskWithDelay(number)))
+      .toList();
+
+    VirtualFuture.allOf(futures.toArray(VirtualFuture[]::new)).join();
+
+    var summationResult = sumResultsOfAllFutures(futures);
+    var endTime = Instant.now();
+
+    var taskDuration = Duration.between(startTime, endTime);
+    var expectedResult = sumOfIntegerRange(range.getMinimum(), range.getMaximum());
+    assertThat(summationResult).isEqualTo(expectedResult);
+    assertThat(taskDuration)
+      .isLessThanOrEqualTo(Duration.ofSeconds(MUCH_LESS_TIME_THAN_SUM_OF_DELAYS));
+
+  }
+
+  @Test
+  void shouldNotHaveATaskWhenCombiningFutures() throws ExecutionException, InterruptedException {
+    var future = VirtualFuture.supply(this::task);
+    var combinedFuture = VirtualFuture.allOf(future);
+    assertThat(combinedFuture.get()).isNull();
+  }
+
+  private static Integer sumResultsOfAllFutures(List<VirtualFuture<Integer>> futures) {
+    return futures.stream()
+      .map(attempt(VirtualFuture::get))
+      .map(Try::orElseThrow)
+      .reduce(Integer::sum)
+      .orElseThrow();
+  }
+
+  private static int sumOfIntegerRange(int minInclusive, int maxInclusive) {
+    var amountOfNumbers = 1 + maxInclusive - minInclusive;
+    return (minInclusive + maxInclusive) * amountOfNumbers / 2;
+
+  }
+
   private Integer task() {
     return TASK_RESULT;
+  }
+
+  private Integer taskWithDelay(int input) {
+    delay();
+    return input;
+  }
+
+  private void delay() {
+    try {
+      Thread.sleep(Duration.ofSeconds(1));
+    } catch (InterruptedException e) {
+      throw new RuntimeException(e);
+    }
   }
 
 }

--- a/misc/src/test/java/com/github/awsjavakit/misc/virtualfuture/VirtualFutureTest.java
+++ b/misc/src/test/java/com/github/awsjavakit/misc/virtualfuture/VirtualFutureTest.java
@@ -3,6 +3,7 @@ package com.github.awsjavakit.misc.virtualfuture;
 import static com.github.awsjavakit.testingutils.RandomDataGenerator.randomInteger;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
+import java.util.List;
 import java.util.concurrent.ExecutionException;
 import org.junit.jupiter.api.Test;
 
@@ -16,6 +17,21 @@ class VirtualFutureTest {
     future.join();
     var result = future.get();
     assertThat(result).isEqualTo(TASK_RESULT);
+  }
+
+  @Test
+  void shouldCombineMultipleFutures() throws ExecutionException, InterruptedException {
+    var futures = List.of(
+      VirtualFuture.supply(this::task),
+      VirtualFuture.supply(this::task)
+    );
+    var awaitAllTasks =
+      VirtualFuture.allOf(futures.toArray(VirtualFuture[]::new));
+    awaitAllTasks.join();
+
+    for (var future : futures) {
+      assertThat(future.get()).isEqualTo(TASK_RESULT);
+    }
   }
 
   private Integer task() {


### PR DESCRIPTION
A first take on Futures and Virtual Threads.  The motivation is to create a basic functional interface using Virtual Threads.
I am basically copying this article (https://blogs.oracle.com/javamagazine/post/virtual-threads-futures) to create a Future similar to the CompletableFuture (it seems that CompletableFutures are using OS threads).

The idea is to add later map-like function to the futures so that we can chain different operations. The map function will come later though.

